### PR TITLE
Fix Add/Remove logic of updating virtual balances

### DIFF
--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -24,8 +24,8 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
     using FixedPoint for uint256;
 
     // uint256 private constant _MIN_SWAP_FEE_PERCENTAGE = 0.001e16; // 0.001%
-    uint256 private constant _MIN_SWAP_FEE_PERCENTAGE = 0;
-    uint256 private constant _MAX_SWAP_FEE_PERCENTAGE = 10e16; // 10%
+    uint256 internal constant _MIN_SWAP_FEE_PERCENTAGE = 0;
+    uint256 internal constant _MAX_SWAP_FEE_PERCENTAGE = 10e16; // 10%
 
     // A pool is "centered" when it holds equal (non-zero) value in both real token balances. In this state, the ratio
     // of the real balances equals the ratio of the virtual balances, and the value of the centeredness measure is
@@ -35,14 +35,14 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
     // centeredness is the divisor in many calculations, zero values would revert, and even near-zero values are
     // problematic. Imposing this limit on centeredness (i.e., reverting if an operation would cause the centeredness
     // to decrease below this threshold) keeps the math well-behaved.
-    uint256 private constant _MIN_TOKEN_BALANCE_SCALED18 = 1e14;
-    uint256 private constant _MIN_POOL_CENTEREDNESS = 1e3;
+    uint256 internal constant _MIN_TOKEN_BALANCE_SCALED18 = 1e14;
+    uint256 internal constant _MIN_POOL_CENTEREDNESS = 1e3;
 
-    SqrtPriceRatioState private _sqrtPriceRatioState;
-    uint256 private _lastTimestamp;
-    uint256 private _timeConstant;
-    uint256 private _centerednessMargin;
-    uint256[] private _lastVirtualBalances;
+    SqrtPriceRatioState internal _sqrtPriceRatioState;
+    uint256 internal _lastTimestamp;
+    uint256 internal _timeConstant;
+    uint256 internal _centerednessMargin;
+    uint256[] internal _lastVirtualBalances;
 
     constructor(
         ReClammPoolParams memory params,

--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -256,17 +256,17 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
     }
 
     /// @inheritdoc IReClammPool
-    function getLastTimestamp() external view returns (uint32) {
-        return _lastTimestamp;
-    }
-
-    /// @inheritdoc IReClammPool
     function setSqrtPriceRatio(
         uint96 newSqrtPriceRatio,
         uint32 startTime,
         uint32 endTime
     ) external onlySwapFeeManagerOrGovernance(address(this)) {
         _setSqrtPriceRatio(newSqrtPriceRatio, startTime, endTime);
+    }
+
+    /// @inheritdoc IReClammPool
+    function getLastTimestamp() external view returns (uint32) {
+        return _lastTimestamp;
     }
 
     /// @inheritdoc IReClammPool

--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -251,6 +251,11 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
     }
 
     /// @inheritdoc IReClammPool
+    function getLastTimestamp() external view returns (uint32) {
+        return _lastTimestamp;
+    }
+
+    /// @inheritdoc IReClammPool
     function getCurrentSqrtPriceRatio() external view override returns (uint96) {
         return _calculateCurrentSqrtPriceRatio();
     }
@@ -262,11 +267,6 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
         uint32 endTime
     ) external onlySwapFeeManagerOrGovernance(address(this)) {
         _setSqrtPriceRatio(newSqrtPriceRatio, startTime, endTime);
-    }
-
-    /// @inheritdoc IReClammPool
-    function getLastTimestamp() external view returns (uint32) {
-        return _lastTimestamp;
     }
 
     /// @inheritdoc IReClammPool

--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -42,11 +42,11 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
     uint256 internal constant _MIN_TOKEN_BALANCE_SCALED18 = 1e14;
     uint256 internal constant _MIN_POOL_CENTEREDNESS = 1e3;
 
-    SqrtPriceRatioState private _sqrtPriceRatioState;
-    uint32 private _lastTimestamp;
-    uint128 private _timeConstant;
-    uint64 private _centerednessMargin;
-    uint256[] private _lastVirtualBalances;
+    SqrtPriceRatioState internal _sqrtPriceRatioState;
+    uint32 internal _lastTimestamp;
+    uint128 internal _timeConstant;
+    uint64 internal _centerednessMargin;
+    uint256[] internal _lastVirtualBalances;
 
     modifier withUpdatedTimestamp() {
         _updateTimestamp();

--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -282,15 +282,14 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
             balancesScaled18,
             _lastVirtualBalances,
             _timeConstant,
-            uint32(_lastTimestamp),
-            uint32(block.timestamp),
+            _lastTimestamp,
+            block.timestamp.toUint32(),
             _centerednessMargin,
             _sqrtPriceRatioState
         );
     }
 
-    function _setLastVirtualBalances(uint256[] memory virtualBalances) internal {
-        _lastTimestamp = block.timestamp;
+    function _setLastVirtualBalances(uint256[] memory virtualBalances) internal withUpdatedTimestamp {
         _lastVirtualBalances = virtualBalances;
 
         emit VirtualBalancesUpdated(virtualBalances);

--- a/contracts/interfaces/IReClammPool.sol
+++ b/contracts/interfaces/IReClammPool.sol
@@ -37,7 +37,7 @@ interface IReClammPool is IBasePool {
 
     function getCurrentVirtualBalances() external view returns (uint256[] memory currentVirtualBalances);
 
-    function getLastTimestamp() external view returns (uint256);
+    function getLastTimestamp() external view returns (uint32);
 
     function getCurrentSqrtPriceRatio() external view returns (uint96);
 

--- a/contracts/test/ReClammPoolMock.sol
+++ b/contracts/test/ReClammPoolMock.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.24;
 
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 
 import { ReClammPool } from "../ReClammPool.sol";
@@ -12,7 +14,15 @@ contract ReClammPoolMock is ReClammPool {
         // solhint-disable-previous-line no-empty-blocks
     }
 
+    function getLastVirtualBalances() external view returns (uint256[] memory) {
+        return _lastVirtualBalances;
+    }
+
     function setCenterednessMargin(uint256 newCenterednessMargin) external {
         _setCenterednessMargin(newCenterednessMargin);
+    }
+
+    function setLastTimestamp(uint256 newLastTimestamp) external {
+        _lastTimestamp = SafeCast.toUint32(newLastTimestamp);
     }
 }

--- a/test/foundry/ReClammLiquidity.t.sol
+++ b/test/foundry/ReClammLiquidity.t.sol
@@ -6,6 +6,7 @@ import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/Fixe
 import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 
 import { IReClammPool } from "../../contracts/interfaces/IReClammPool.sol";
+import { ReClammPoolMock } from "../../contracts/test/ReClammPoolMock.sol";
 import { ReClammMath } from "../../contracts/lib/ReClammMath.sol";
 import { BaseReClammTest } from "./utils/BaseReClammTest.sol";
 import { ReClammPool } from "../../contracts/ReClammPool.sol";
@@ -54,6 +55,57 @@ contract ReClammLiquidityTest is BaseReClammTest {
         );
 
         _checkPriceAndCenteredness(balancesBefore, balancesAfter, virtualBalancesBefore, virtualBalancesAfter);
+    }
+
+    function testAddLiquidityOutOfRange__Fuzz(
+        uint256 exactBptAmountOut,
+        uint256 initialDaiBalance,
+        uint256 initialUsdcBalance
+    ) public {
+        uint256[] memory initialBalancesScaled18 = _setPoolBalances(initialDaiBalance, initialUsdcBalance);
+        _setLastTimestamp(block.timestamp);
+
+        // Pass 6 hour
+        vm.warp(block.timestamp + 6 * 3600);
+
+        uint256[] memory virtualBalancesBefore = ReClammPool(pool).getCurrentVirtualBalances();
+
+        // Make sure pool is out of range, so the virtual balances should be updated by the addLiquidity call.
+        vm.assume(
+            ReClammMath.isPoolInRange(initialBalancesScaled18, virtualBalancesBefore, _DEFAULT_CENTEREDNESS_MARGIN) ==
+                false
+        );
+
+        uint256 totalSupply = vault.totalSupply(pool);
+        exactBptAmountOut = bound(exactBptAmountOut, 1e6, 100 * totalSupply);
+
+        uint256[] memory maxAmountsIn = new uint256[](2);
+        maxAmountsIn[daiIdx] = dai.balanceOf(alice);
+        maxAmountsIn[usdcIdx] = usdc.balanceOf(alice);
+
+        vm.prank(alice);
+        router.addLiquidityProportional(pool, maxAmountsIn, exactBptAmountOut, false, "");
+
+        uint256[] memory virtualBalancesAfter = ReClammPool(pool).getCurrentVirtualBalances();
+
+        // Check if virtual balances were correctly updated.
+        uint256 proportion = exactBptAmountOut.divUp(totalSupply);
+        assertEq(
+            virtualBalancesAfter[daiIdx],
+            virtualBalancesBefore[daiIdx].mulUp(FixedPoint.ONE + proportion),
+            "DAI virtual balance does not match"
+        );
+        assertEq(
+            virtualBalancesAfter[usdcIdx],
+            virtualBalancesBefore[usdcIdx].mulUp(FixedPoint.ONE + proportion),
+            "USDC virtual balance does not match"
+        );
+
+        assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp was not updated");
+
+        uint256[] memory lastVirtualBalances = ReClammPoolMock(pool).getLastVirtualBalances();
+        assertEq(lastVirtualBalances[daiIdx], virtualBalancesAfter[daiIdx], "DAI virtual balance does not match");
+        assertEq(lastVirtualBalances[usdcIdx], virtualBalancesAfter[usdcIdx], "USDC virtual balance does not match");
     }
 
     function testAddLiquidityUnbalanced() public {
@@ -107,6 +159,57 @@ contract ReClammLiquidityTest is BaseReClammTest {
         _checkPriceAndCenteredness(balancesBefore, balancesAfter, virtualBalancesBefore, virtualBalancesAfter);
     }
 
+    function testRemoveLiquidityOutOfRange__Fuzz(
+        uint256 exactBptAmountIn,
+        uint256 initialDaiBalance,
+        uint256 initialUsdcBalance
+    ) public {
+        uint256[] memory initialBalancesScaled18 = _setPoolBalances(initialDaiBalance, initialUsdcBalance);
+        _setLastTimestamp(block.timestamp);
+
+        // Pass 6 hour
+        vm.warp(block.timestamp + 6 * 3600);
+
+        uint256[] memory virtualBalancesBefore = ReClammPool(pool).getCurrentVirtualBalances();
+
+        // Make sure pool is out of range, so the virtual balances should be updated by the addLiquidity call.
+        vm.assume(
+            ReClammMath.isPoolInRange(initialBalancesScaled18, virtualBalancesBefore, _DEFAULT_CENTEREDNESS_MARGIN) ==
+                false
+        );
+
+        uint256 totalSupply = vault.totalSupply(pool);
+        exactBptAmountIn = bound(exactBptAmountIn, 1e6, (9 * totalSupply) / 10);
+
+        uint256[] memory minAmountsOut = new uint256[](2);
+        minAmountsOut[daiIdx] = 0;
+        minAmountsOut[usdcIdx] = 0;
+
+        vm.prank(lp);
+        router.removeLiquidityProportional(pool, exactBptAmountIn, minAmountsOut, false, "");
+
+        uint256[] memory virtualBalancesAfter = ReClammPool(pool).getCurrentVirtualBalances();
+
+        // Check if virtual balances were correctly updated.
+        uint256 proportion = exactBptAmountIn.divUp(totalSupply);
+        assertEq(
+            virtualBalancesAfter[daiIdx],
+            virtualBalancesBefore[daiIdx].mulDown(FixedPoint.ONE - proportion),
+            "DAI virtual balance does not match"
+        );
+        assertEq(
+            virtualBalancesAfter[usdcIdx],
+            virtualBalancesBefore[usdcIdx].mulDown(FixedPoint.ONE - proportion),
+            "USDC virtual balance does not match"
+        );
+
+        assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp was not updated");
+
+        uint256[] memory lastVirtualBalances = ReClammPoolMock(pool).getLastVirtualBalances();
+        assertEq(lastVirtualBalances[daiIdx], virtualBalancesAfter[daiIdx], "DAI virtual balance does not match");
+        assertEq(lastVirtualBalances[usdcIdx], virtualBalancesAfter[usdcIdx], "USDC virtual balance does not match");
+    }
+
     function testRemoveLiquidityBelowMinTokenBalance() public {
         _setPoolBalances(100 * _MIN_TOKEN_BALANCE, 100 * _MIN_TOKEN_BALANCE);
 
@@ -158,16 +261,23 @@ contract ReClammLiquidityTest is BaseReClammTest {
         assertApproxEqAbs(centerednessAfter, centerednessBefore, _MAX_CENTEREDNESS_ERROR_ABS, "Centeredness changed");
     }
 
-    function _setPoolBalances(uint256 initialDaiBalance, uint256 initialUsdcBalance) internal {
+    function _setPoolBalances(
+        uint256 initialDaiBalance,
+        uint256 initialUsdcBalance
+    ) internal returns (uint256[] memory initialBalances) {
         // Setting initial balances to be at least 10 * min token balance, so LP can remove 90% of the liquidity
         // without reverting.
         initialDaiBalance = bound(initialDaiBalance, 10 * _MIN_TOKEN_BALANCE, dai.balanceOf(address(vault)));
         initialUsdcBalance = bound(initialUsdcBalance, 10 * _MIN_TOKEN_BALANCE, usdc.balanceOf(address(vault)));
 
-        uint256[] memory initialBalances = new uint256[](2);
+        initialBalances = new uint256[](2);
         initialBalances[daiIdx] = initialDaiBalance;
         initialBalances[usdcIdx] = initialUsdcBalance;
 
         vault.manualSetPoolBalances(pool, initialBalances, initialBalances);
+    }
+
+    function _setLastTimestamp(uint256 timestamp) internal {
+        ReClammPoolMock(pool).setLastTimestamp(timestamp);
     }
 }

--- a/test/foundry/ReClammLiquidity.t.sol
+++ b/test/foundry/ReClammLiquidity.t.sol
@@ -16,7 +16,6 @@ contract ReClammLiquidityTest is BaseReClammTest {
 
     uint256 constant _MAX_PRICE_ERROR_ABS = 5;
     uint256 constant _MAX_CENTEREDNESS_ERROR_ABS = 1e5;
-    uint256 constant _MIN_TOKEN_BALANCE = 1e14;
 
     function testAddLiquidity_Fuzz(
         uint256 exactBptAmountOut,
@@ -63,7 +62,7 @@ contract ReClammLiquidityTest is BaseReClammTest {
         uint256 initialUsdcBalance
     ) public {
         uint256[] memory initialBalancesScaled18 = _setPoolBalances(initialDaiBalance, initialUsdcBalance);
-        _setLastTimestamp(block.timestamp);
+        ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
 
         // Pass 6 hour
         vm.warp(block.timestamp + 6 * 3600);
@@ -165,7 +164,7 @@ contract ReClammLiquidityTest is BaseReClammTest {
         uint256 initialUsdcBalance
     ) public {
         uint256[] memory initialBalancesScaled18 = _setPoolBalances(initialDaiBalance, initialUsdcBalance);
-        _setLastTimestamp(block.timestamp);
+        ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
 
         // Pass 6 hour
         vm.warp(block.timestamp + 6 * 3600);
@@ -259,25 +258,5 @@ contract ReClammLiquidityTest is BaseReClammTest {
         uint256 centerednessBefore = ReClammMath.calculateCenteredness(balancesBefore, virtualBalancesBefore);
         uint256 centerednessAfter = ReClammMath.calculateCenteredness(balancesAfter, virtualBalancesAfter);
         assertApproxEqAbs(centerednessAfter, centerednessBefore, _MAX_CENTEREDNESS_ERROR_ABS, "Centeredness changed");
-    }
-
-    function _setPoolBalances(
-        uint256 initialDaiBalance,
-        uint256 initialUsdcBalance
-    ) internal returns (uint256[] memory initialBalances) {
-        // Setting initial balances to be at least 10 * min token balance, so LP can remove 90% of the liquidity
-        // without reverting.
-        initialDaiBalance = bound(initialDaiBalance, 10 * _MIN_TOKEN_BALANCE, dai.balanceOf(address(vault)));
-        initialUsdcBalance = bound(initialUsdcBalance, 10 * _MIN_TOKEN_BALANCE, usdc.balanceOf(address(vault)));
-
-        initialBalances = new uint256[](2);
-        initialBalances[daiIdx] = initialDaiBalance;
-        initialBalances[usdcIdx] = initialUsdcBalance;
-
-        vault.manualSetPoolBalances(pool, initialBalances, initialBalances);
-    }
-
-    function _setLastTimestamp(uint256 timestamp) internal {
-        ReClammPoolMock(pool).setLastTimestamp(timestamp);
     }
 }

--- a/test/foundry/ReClammMath.t.sol
+++ b/test/foundry/ReClammMath.t.sol
@@ -12,22 +12,24 @@ import { Rounding } from "@balancer-labs/v3-interfaces/contracts/vault/VaultType
 
 import { ReClammMathMock } from "../../contracts/test/ReClammMathMock.sol";
 import { ReClammMath } from "../../contracts/lib/ReClammMath.sol";
+import { BaseReClammTest } from "./utils/BaseReClammTest.sol";
 
-contract ReClammMathTest is Test {
+contract ReClammMathTest is BaseReClammTest {
     using ArrayHelpers for *;
     using FixedPoint for uint256;
 
     // Constant to increase the price by a factor 2 if increase rate is 100%.
     uint256 private constant _SECONDS_PER_DAY_WITH_ADJUSTMENT = 124649;
     uint256 private constant _MAX_BALANCE = 1e6 * 1e18;
-    uint256 private constant _MIN_BALANCE = 1e14;
+
     uint256 private constant _MIN_POOL_CENTEREDNESS = 1e3;
     uint256 private constant _MAX_CENTEREDNESS_ERROR_ABS = 1e9;
     uint256 private constant _MAX_PRICE_ERROR_ABS = 1e14;
 
     ReClammMathMock internal mathContract;
 
-    function setUp() public {
+    function setUp() public override {
+        super.setUp();
         mathContract = new ReClammMathMock();
     }
 
@@ -80,10 +82,10 @@ contract ReClammMathTest is Test {
         tokenIn = bound(tokenIn, 0, 1);
         uint256 tokenOut = tokenIn == 0 ? 1 : 0;
 
-        balanceA = bound(balanceA, _MIN_BALANCE, _MAX_BALANCE);
-        balanceB = bound(balanceB, _MIN_BALANCE, _MAX_BALANCE);
-        virtualBalanceA = bound(virtualBalanceA, _MIN_BALANCE, _MAX_BALANCE);
-        virtualBalanceB = bound(virtualBalanceB, _MIN_BALANCE, _MAX_BALANCE);
+        balanceA = bound(balanceA, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
+        balanceB = bound(balanceB, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
+        virtualBalanceA = bound(virtualBalanceA, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
+        virtualBalanceB = bound(virtualBalanceB, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
 
         uint256 maxAmount = tokenIn == 0 ? balanceB : balanceA;
         amountGivenScaled18 = bound(amountGivenScaled18, 1, maxAmount);
@@ -136,10 +138,10 @@ contract ReClammMathTest is Test {
         tokenIn = bound(tokenIn, 0, 1);
         uint256 tokenOut = tokenIn == 0 ? 1 : 0;
 
-        balanceA = bound(balanceA, _MIN_BALANCE, _MAX_BALANCE);
-        balanceB = bound(balanceB, _MIN_BALANCE, _MAX_BALANCE);
-        virtualBalanceA = bound(virtualBalanceA, _MIN_BALANCE, _MAX_BALANCE);
-        virtualBalanceB = bound(virtualBalanceB, _MIN_BALANCE, _MAX_BALANCE);
+        balanceA = bound(balanceA, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
+        balanceB = bound(balanceB, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
+        virtualBalanceA = bound(virtualBalanceA, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
+        virtualBalanceB = bound(virtualBalanceB, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
 
         uint256 maxAmount = tokenIn == 0 ? balanceA : balanceB;
         amountGivenScaled18 = bound(amountGivenScaled18, 1, maxAmount);
@@ -227,8 +229,8 @@ contract ReClammMathTest is Test {
     ) public pure {
         balance0 = bound(balance0, 0, _MAX_BALANCE);
         balance1 = bound(balance1, 0, _MAX_BALANCE);
-        virtualBalance0 = bound(virtualBalance0, _MIN_BALANCE, _MAX_BALANCE);
-        virtualBalance1 = bound(virtualBalance1, _MIN_BALANCE, _MAX_BALANCE);
+        virtualBalance0 = bound(virtualBalance0, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
+        virtualBalance1 = bound(virtualBalance1, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
         centerednessMargin = bound(centerednessMargin, 0, 50e16);
 
         uint256[] memory balancesScaled18 = new uint256[](2);
@@ -250,10 +252,10 @@ contract ReClammMathTest is Test {
         uint256 virtualBalance0,
         uint256 virtualBalance1
     ) public pure {
-        balance0 = bound(balance0, _MIN_BALANCE, _MAX_BALANCE);
-        balance1 = bound(balance1, _MIN_BALANCE, _MAX_BALANCE);
-        virtualBalance0 = bound(virtualBalance0, _MIN_BALANCE, _MAX_BALANCE);
-        virtualBalance1 = bound(virtualBalance1, _MIN_BALANCE, _MAX_BALANCE);
+        balance0 = bound(balance0, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
+        balance1 = bound(balance1, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
+        virtualBalance0 = bound(virtualBalance0, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
+        virtualBalance1 = bound(virtualBalance1, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
 
         uint256[] memory balancesScaled18 = new uint256[](2);
         balancesScaled18[0] = balance0;
@@ -290,8 +292,8 @@ contract ReClammMathTest is Test {
     ) public pure {
         balance0 = bound(balance0, 0, _MAX_BALANCE);
         balance1 = bound(balance1, 0, _MAX_BALANCE);
-        virtualBalance0 = bound(virtualBalance0, _MIN_BALANCE, _MAX_BALANCE);
-        virtualBalance1 = bound(virtualBalance1, _MIN_BALANCE, _MAX_BALANCE);
+        virtualBalance0 = bound(virtualBalance0, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
+        virtualBalance1 = bound(virtualBalance1, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
 
         uint256[] memory balancesScaled18 = new uint256[](2);
         balancesScaled18[0] = balance0;
@@ -363,10 +365,10 @@ contract ReClammMathTest is Test {
         uint256 virtualBalance1,
         uint256 expectedSqrtPriceRatio
     ) public pure {
-        balance0 = bound(balance0, _MIN_BALANCE, _MAX_BALANCE);
-        balance1 = bound(balance1, _MIN_BALANCE, _MAX_BALANCE);
-        virtualBalance0 = bound(virtualBalance0, _MIN_BALANCE, _MAX_BALANCE);
-        virtualBalance1 = bound(virtualBalance1, _MIN_BALANCE, _MAX_BALANCE);
+        balance0 = bound(balance0, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
+        balance1 = bound(balance1, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
+        virtualBalance0 = bound(virtualBalance0, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
+        virtualBalance1 = bound(virtualBalance1, _MIN_TOKEN_BALANCE, _MAX_BALANCE);
         expectedSqrtPriceRatio = SafeCast.toUint96(bound(expectedSqrtPriceRatio, 1.1e18, 10e18));
 
         uint256[] memory balancesScaled18 = new uint256[](2);

--- a/test/foundry/ReClammPool.t.sol
+++ b/test/foundry/ReClammPool.t.sol
@@ -57,6 +57,29 @@ contract ReClammPoolTest is BaseReClammTest {
         ReClammPool(pool).setIncreaseDayRate(newIncreaseDayRate);
     }
 
+    function testSetIncreaseDayRateUpdatingVirtualBalance() public {
+        uint256[] memory initialBalancesScaled18 = _setPoolBalances(1e14, 100e18);
+        ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
+
+        // Pass 6 hour
+        vm.warp(block.timestamp + 6 * 3600);
+
+        uint256[] memory virtualBalancesBefore = ReClammPool(pool).getCurrentVirtualBalances();
+
+        uint256 newIncreaseDayRate = 200e16;
+        vm.prank(admin);
+        vm.expectEmit();
+        emit IReClammPool.IncreaseDayRateUpdated(newIncreaseDayRate);
+        ReClammPool(pool).setIncreaseDayRate(newIncreaseDayRate);
+
+        assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp was not updated");
+
+        uint256[] memory lastVirtualBalances = ReClammPoolMock(pool).getLastVirtualBalances();
+
+        assertEq(lastVirtualBalances[daiIdx], virtualBalancesBefore[daiIdx], "DAI virtual balance does not match");
+        assertEq(lastVirtualBalances[usdcIdx], virtualBalancesBefore[usdcIdx], "USDC virtual balance does not match");
+    }
+
     function testSetCenterednessMargin() public {
         // ReCLAMM pools do not have a way to set the margin, so this function uses a mocked version that exposes a
         // private function.

--- a/test/foundry/ReClammPool.t.sol
+++ b/test/foundry/ReClammPool.t.sol
@@ -58,7 +58,7 @@ contract ReClammPoolTest is BaseReClammTest {
     }
 
     function testSetIncreaseDayRateUpdatingVirtualBalance() public {
-        uint256[] memory initialBalancesScaled18 = _setPoolBalances(1e14, 100e18);
+        _setPoolBalances(1e14, 100e18);
         ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
 
         // Pass 6 hour

--- a/test/foundry/ReClammPoolVirtualBalances.t.sol
+++ b/test/foundry/ReClammPoolVirtualBalances.t.sol
@@ -19,7 +19,6 @@ contract ReClammPoolVirtualBalancesTest is BaseReClammTest {
     using ArrayHelpers for *;
 
     uint256 private constant _PRICE_RANGE = 2e18; // Max price is 2x min price.
-    uint256 private constant _MIN_TOKEN_BALANCE = 1e14;
     uint256 private constant _INITIAL_BALANCE_A = 1_000_000e18;
     uint256 private constant _INITIAL_BALANCE_B = 100_000e18;
 

--- a/test/foundry/utils/BaseReClammTest.sol
+++ b/test/foundry/utils/BaseReClammTest.sol
@@ -36,7 +36,7 @@ contract BaseReClammTest is ReClammPoolContractsDeployer, BaseVaultTest {
 
     uint256 internal constant _DEFAULT_INCREASE_DAY_RATE = 100e16; // 100%
     uint96 internal constant _DEFAULT_SQRT_PRICE_RATIO = 1.41421356e18; // Price Range of 4 (fourth square root is 1.41)
-    uint256 internal constant _DEFAULT_CENTEREDNESS_MARGIN = 10e16; // 10%
+    uint256 internal constant _DEFAULT_CENTEREDNESS_MARGIN = 20e16; // 20%
 
     uint96 private _sqrtPriceRatio = _DEFAULT_SQRT_PRICE_RATIO;
     uint256 private _increaseDayRate = _DEFAULT_INCREASE_DAY_RATE;

--- a/test/foundry/utils/BaseReClammTest.sol
+++ b/test/foundry/utils/BaseReClammTest.sol
@@ -140,18 +140,18 @@ contract BaseReClammTest is ReClammPoolContractsDeployer, BaseVaultTest {
     }
 
     function _setPoolBalances(
-        uint256 initialDaiBalance,
-        uint256 initialUsdcBalance
-    ) internal returns (uint256[] memory initialBalances) {
-        // Setting initial balances to be at least 10 * min token balance, so LP can remove 90% of the liquidity
+        uint256 daiBalance,
+        uint256 usdcBalance
+    ) internal returns (uint256[] memory newPoolBalances) {
+        // Setting balances to be at least 10 * min token balance, so LP can remove 90% of the liquidity
         // without reverting.
-        initialDaiBalance = bound(initialDaiBalance, 10 * _MIN_TOKEN_BALANCE, dai.balanceOf(address(vault)));
-        initialUsdcBalance = bound(initialUsdcBalance, 10 * _MIN_TOKEN_BALANCE, usdc.balanceOf(address(vault)));
+        daiBalance = bound(daiBalance, 10 * _MIN_TOKEN_BALANCE, dai.balanceOf(address(vault)));
+        usdcBalance = bound(usdcBalance, 10 * _MIN_TOKEN_BALANCE, usdc.balanceOf(address(vault)));
 
-        initialBalances = new uint256[](2);
-        initialBalances[daiIdx] = initialDaiBalance;
-        initialBalances[usdcIdx] = initialUsdcBalance;
+        newPoolBalances = new uint256[](2);
+        newPoolBalances[daiIdx] = daiBalance;
+        newPoolBalances[usdcIdx] = usdcBalance;
 
-        vault.manualSetPoolBalances(pool, initialBalances, initialBalances);
+        vault.manualSetPoolBalances(pool, newPoolBalances, newPoolBalances);
     }
 }

--- a/test/foundry/utils/BaseReClammTest.sol
+++ b/test/foundry/utils/BaseReClammTest.sol
@@ -37,6 +37,7 @@ contract BaseReClammTest is ReClammPoolContractsDeployer, BaseVaultTest {
     uint256 internal constant _DEFAULT_INCREASE_DAY_RATE = 100e16; // 100%
     uint96 internal constant _DEFAULT_SQRT_PRICE_RATIO = 1.41421356e18; // Price Range of 4 (fourth square root is 1.41)
     uint256 internal constant _DEFAULT_CENTEREDNESS_MARGIN = 20e16; // 20%
+    uint256 internal constant _MIN_TOKEN_BALANCE = 1e14;
 
     uint96 private _sqrtPriceRatio = _DEFAULT_SQRT_PRICE_RATIO;
     uint256 private _increaseDayRate = _DEFAULT_INCREASE_DAY_RATE;
@@ -136,5 +137,21 @@ contract BaseReClammTest is ReClammPoolContractsDeployer, BaseVaultTest {
         vm.startPrank(lp);
         _initPool(pool, _initialBalances, 0);
         vm.stopPrank();
+    }
+
+    function _setPoolBalances(
+        uint256 initialDaiBalance,
+        uint256 initialUsdcBalance
+    ) internal returns (uint256[] memory initialBalances) {
+        // Setting initial balances to be at least 10 * min token balance, so LP can remove 90% of the liquidity
+        // without reverting.
+        initialDaiBalance = bound(initialDaiBalance, 10 * _MIN_TOKEN_BALANCE, dai.balanceOf(address(vault)));
+        initialUsdcBalance = bound(initialUsdcBalance, 10 * _MIN_TOKEN_BALANCE, usdc.balanceOf(address(vault)));
+
+        initialBalances = new uint256[](2);
+        initialBalances[daiIdx] = initialDaiBalance;
+        initialBalances[usdcIdx] = initialUsdcBalance;
+
+        vault.manualSetPoolBalances(pool, initialBalances, initialBalances);
     }
 }


### PR DESCRIPTION
# Description

Add/Remove logic of updating virtual balances had a bug: It was using the currentVirtualBalances, which adjusted the virtual balances to the current timestamp, but it wasn't setting the lastTimestamp.

We had 2 alternatives: Adjust based on the lastVirtualBalances, or update the timestamp. We chose the last one, since it's more symmetric with Swap and Set operations.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge
