### PR TITLE
Check if swaps are updating virtual balances and timestamps correctly

### DIFF
--- a/test/foundry/ReClammLiquidity.t.sol
+++ b/test/foundry/ReClammLiquidity.t.sol
@@ -65,7 +65,6 @@ contract ReClammLiquidityTest is BaseReClammTest {
         uint256[] memory initialBalancesScaled18 = _setPoolBalances(initialDaiBalance, initialUsdcBalance);
         ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
 
-        // Wait 6 hours.
         vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory virtualBalancesBefore = ReClammPool(pool).getCurrentVirtualBalances();
@@ -212,7 +211,6 @@ contract ReClammLiquidityTest is BaseReClammTest {
         uint256[] memory initialBalancesScaled18 = _setPoolBalances(initialDaiBalance, initialUsdcBalance);
         ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
 
-        // Wait 6 hours.
         vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory virtualBalancesBefore = ReClammPool(pool).getCurrentVirtualBalances();

--- a/test/foundry/ReClammLiquidity.t.sol
+++ b/test/foundry/ReClammLiquidity.t.sol
@@ -46,12 +46,12 @@ contract ReClammLiquidityTest is BaseReClammTest {
         assertEq(
             virtualBalancesAfter[daiIdx],
             virtualBalancesBefore[daiIdx].mulUp(FixedPoint.ONE + proportion),
-            "DAI virtual balance does not match"
+            "DAI virtual balances do not match"
         );
         assertEq(
             virtualBalancesAfter[usdcIdx],
             virtualBalancesBefore[usdcIdx].mulUp(FixedPoint.ONE + proportion),
-            "USDC virtual balance does not match"
+            "USDC virtual balances do not match"
         );
 
         _checkPriceAndCenteredness(balancesBefore, balancesAfter, virtualBalancesBefore, virtualBalancesAfter);
@@ -93,19 +93,19 @@ contract ReClammLiquidityTest is BaseReClammTest {
         assertEq(
             virtualBalancesAfter[daiIdx],
             virtualBalancesBefore[daiIdx].mulUp(FixedPoint.ONE + proportion),
-            "DAI virtual balance does not match"
+            "DAI virtual balances do not match"
         );
         assertEq(
             virtualBalancesAfter[usdcIdx],
             virtualBalancesBefore[usdcIdx].mulUp(FixedPoint.ONE + proportion),
-            "USDC virtual balance does not match"
+            "USDC virtual balances do not match"
         );
 
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp was not updated");
 
         uint256[] memory lastVirtualBalances = ReClammPoolMock(pool).getLastVirtualBalances();
-        assertEq(lastVirtualBalances[daiIdx], virtualBalancesAfter[daiIdx], "DAI virtual balance does not match");
-        assertEq(lastVirtualBalances[usdcIdx], virtualBalancesAfter[usdcIdx], "USDC virtual balance does not match");
+        assertEq(lastVirtualBalances[daiIdx], virtualBalancesAfter[daiIdx], "DAI virtual balances do not match");
+        assertEq(lastVirtualBalances[usdcIdx], virtualBalancesAfter[usdcIdx], "USDC virtual balances do not match");
     }
 
     function testAddLiquidityUnbalanced() public {
@@ -193,12 +193,12 @@ contract ReClammLiquidityTest is BaseReClammTest {
         assertEq(
             virtualBalancesAfter[daiIdx],
             virtualBalancesBefore[daiIdx].mulDown(FixedPoint.ONE - proportion),
-            "DAI virtual balance does not match"
+            "DAI virtual balances do not match"
         );
         assertEq(
             virtualBalancesAfter[usdcIdx],
             virtualBalancesBefore[usdcIdx].mulDown(FixedPoint.ONE - proportion),
-            "USDC virtual balance does not match"
+            "USDC virtual balances do not match"
         );
 
         _checkPriceAndCenteredness(balancesBefore, balancesAfter, virtualBalancesBefore, virtualBalancesAfter);
@@ -240,19 +240,19 @@ contract ReClammLiquidityTest is BaseReClammTest {
         assertEq(
             virtualBalancesAfter[daiIdx],
             virtualBalancesBefore[daiIdx].mulDown(FixedPoint.ONE - proportion),
-            "DAI virtual balance does not match"
+            "DAI virtual balances do not match"
         );
         assertEq(
             virtualBalancesAfter[usdcIdx],
             virtualBalancesBefore[usdcIdx].mulDown(FixedPoint.ONE - proportion),
-            "USDC virtual balance does not match"
+            "USDC virtual balances do not match"
         );
 
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp was not updated");
 
         uint256[] memory lastVirtualBalances = ReClammPoolMock(pool).getLastVirtualBalances();
-        assertEq(lastVirtualBalances[daiIdx], virtualBalancesAfter[daiIdx], "DAI virtual balance does not match");
-        assertEq(lastVirtualBalances[usdcIdx], virtualBalancesAfter[usdcIdx], "USDC virtual balance does not match");
+        assertEq(lastVirtualBalances[daiIdx], virtualBalancesAfter[daiIdx], "DAI virtual balances do not match");
+        assertEq(lastVirtualBalances[usdcIdx], virtualBalancesAfter[usdcIdx], "USDC virtual balances do not match");
     }
 
     function testRemoveLiquidityBelowMinTokenBalance() public {

--- a/test/foundry/ReClammLiquidity.t.sol
+++ b/test/foundry/ReClammLiquidity.t.sol
@@ -65,8 +65,8 @@ contract ReClammLiquidityTest is BaseReClammTest {
         uint256[] memory initialBalancesScaled18 = _setPoolBalances(initialDaiBalance, initialUsdcBalance);
         ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
 
-        // Pass 6 hour
-        vm.warp(block.timestamp + 6 * 3600);
+        // Wait 6 hours.
+        vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory virtualBalancesBefore = ReClammPool(pool).getCurrentVirtualBalances();
 
@@ -212,8 +212,8 @@ contract ReClammLiquidityTest is BaseReClammTest {
         uint256[] memory initialBalancesScaled18 = _setPoolBalances(initialDaiBalance, initialUsdcBalance);
         ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
 
-        // Pass 6 hour
-        vm.warp(block.timestamp + 6 * 3600);
+        // Wait 6 hours.
+        vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory virtualBalancesBefore = ReClammPool(pool).getCurrentVirtualBalances();
 

--- a/test/foundry/ReClammPool.t.sol
+++ b/test/foundry/ReClammPool.t.sol
@@ -81,8 +81,8 @@ contract ReClammPoolTest is BaseReClammTest {
 
         uint256[] memory lastVirtualBalances = ReClammPoolMock(pool).getLastVirtualBalances();
 
-        assertEq(lastVirtualBalances[daiIdx], virtualBalancesBefore[daiIdx], "DAI virtual balance does not match");
-        assertEq(lastVirtualBalances[usdcIdx], virtualBalancesBefore[usdcIdx], "USDC virtual balance does not match");
+        assertEq(lastVirtualBalances[daiIdx], virtualBalancesBefore[daiIdx], "DAI virtual balances do not match");
+        assertEq(lastVirtualBalances[usdcIdx], virtualBalancesBefore[usdcIdx], "USDC virtual balances do not match");
     }
 
     function testSetCenterednessMargin() public {

--- a/test/foundry/ReClammPool.t.sol
+++ b/test/foundry/ReClammPool.t.sol
@@ -66,7 +66,6 @@ contract ReClammPoolTest is BaseReClammTest {
         _setPoolBalances(1e14, 100e18);
         ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
 
-        // Wait 6 hours.
         vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory virtualBalancesBefore = ReClammPool(pool).getCurrentVirtualBalances();

--- a/test/foundry/ReClammPool.t.sol
+++ b/test/foundry/ReClammPool.t.sol
@@ -66,8 +66,8 @@ contract ReClammPoolTest is BaseReClammTest {
         _setPoolBalances(1e14, 100e18);
         ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
 
-        // Pass 6 hour
-        vm.warp(block.timestamp + 6 * 3600);
+        // Wait 6 hours.
+        vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory virtualBalancesBefore = ReClammPool(pool).getCurrentVirtualBalances();
 

--- a/test/foundry/ReClammSwap.t.sol
+++ b/test/foundry/ReClammSwap.t.sol
@@ -176,4 +176,149 @@ contract ReClammSwapTest is BaseReClammTest {
 
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
     }
+
+    function testSwapExactOutOutOfRange__Fuzz(uint256 daiBalance, uint256 usdcBalance) public {
+        // Set the pool balances.
+        uint256[] memory newBalances = _setPoolBalances(daiBalance, usdcBalance);
+
+        // Set the last timestamp.
+        ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
+
+        // Pass 6 hours.
+        vm.warp(block.timestamp + 6 * 3600);
+
+        uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
+        uint256[] memory currentVirtualBalances = ReClammPool(pool).getCurrentVirtualBalances();
+
+        vm.assume(
+            ReClammMath.isPoolInRange(newBalances, lastVirtualBalancesBeforeSwap, _DEFAULT_CENTEREDNESS_MARGIN) == false
+        );
+
+        // If the pool is out of range, the virtual balances should not match.
+        assertNotEq(
+            lastVirtualBalancesBeforeSwap[daiIdx],
+            currentVirtualBalances[daiIdx],
+            "DAI virtual balance are matching"
+        );
+        assertNotEq(
+            lastVirtualBalancesBeforeSwap[usdcIdx],
+            currentVirtualBalances[usdcIdx],
+            "USDC virtual balance are matching"
+        );
+
+        uint256 amountUsdcOut = (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2;
+
+        vm.prank(alice);
+        router.swapSingleTokenExactOut(pool, dai, usdc, amountUsdcOut, MAX_UINT256, MAX_UINT256, false, bytes(""));
+
+        uint256[] memory lastVirtualBalancesAfterSwap = ReClammPoolMock(pool).getLastVirtualBalances();
+
+        assertEq(
+            lastVirtualBalancesAfterSwap[daiIdx],
+            currentVirtualBalances[daiIdx],
+            "DAI virtual balance does not match"
+        );
+        assertEq(
+            lastVirtualBalancesAfterSwap[usdcIdx],
+            currentVirtualBalances[usdcIdx],
+            "USDC virtual balance does not match"
+        );
+
+        assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
+    }
+
+    function testSwapExactOutPriceRatioUpdating__Fuzz(uint256 newFourthRootPriceRatio) public {
+        uint256 currentFourthRootPriceRatio = ReClammPool(pool).getCurrentFourthRootPriceRatio();
+        newFourthRootPriceRatio = bound(newFourthRootPriceRatio, 1.1e18, 10e18);
+        vm.assume(currentFourthRootPriceRatio != newFourthRootPriceRatio);
+
+        vm.prank(admin);
+        ReClammPool(pool).setPriceRatioState(newFourthRootPriceRatio, block.timestamp, block.timestamp + 24 * 3600);
+
+        // Pass 6 hours.
+        vm.warp(block.timestamp + 6 * 3600);
+
+        uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
+        uint256[] memory currentVirtualBalances = ReClammPool(pool).getCurrentVirtualBalances();
+
+        // If the price ratio is updating, the virtual balances should not match.
+        assertNotEq(
+            lastVirtualBalancesBeforeSwap[daiIdx],
+            currentVirtualBalances[daiIdx],
+            "DAI virtual balance are matching"
+        );
+        assertNotEq(
+            lastVirtualBalancesBeforeSwap[usdcIdx],
+            currentVirtualBalances[usdcIdx],
+            "USDC virtual balance are matching"
+        );
+
+        uint256 amountUsdcOut = (poolInitAmount - _MIN_TOKEN_BALANCE) / 2;
+
+        vm.prank(alice);
+        router.swapSingleTokenExactOut(pool, dai, usdc, amountUsdcOut, MAX_UINT256, MAX_UINT256, false, bytes(""));
+
+        uint256[] memory lastVirtualBalancesAfterSwap = ReClammPoolMock(pool).getLastVirtualBalances();
+
+        assertEq(
+            lastVirtualBalancesAfterSwap[daiIdx],
+            currentVirtualBalances[daiIdx],
+            "DAI virtual balance does not match"
+        );
+        assertEq(
+            lastVirtualBalancesAfterSwap[usdcIdx],
+            currentVirtualBalances[usdcIdx],
+            "USDC virtual balance does not match"
+        );
+
+        assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
+    }
+
+    function testSwapExactOutInRange__Fuzz(uint256 daiBalance, uint256 usdcBalance) public {
+        // Set the pool balances.
+        uint256[] memory newBalances = _setPoolBalances(daiBalance, usdcBalance);
+
+        // Set the last timestamp.
+        ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
+
+        // Pass 6 hours.
+        vm.warp(block.timestamp + 6 * 3600);
+
+        uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
+        uint256[] memory currentVirtualBalances = ReClammPool(pool).getCurrentVirtualBalances();
+
+        vm.assume(ReClammMath.isPoolInRange(newBalances, lastVirtualBalancesBeforeSwap, _DEFAULT_CENTEREDNESS_MARGIN));
+
+        // If the pool is in range, the virtual balances should match.
+        assertEq(
+            lastVirtualBalancesBeforeSwap[daiIdx],
+            currentVirtualBalances[daiIdx],
+            "DAI virtual balance are not matching"
+        );
+        assertEq(
+            lastVirtualBalancesBeforeSwap[usdcIdx],
+            currentVirtualBalances[usdcIdx],
+            "USDC virtual balance are not matching"
+        );
+
+        uint256 amountUsdcOut = (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2;
+
+        vm.prank(alice);
+        router.swapSingleTokenExactOut(pool, dai, usdc, amountUsdcOut, MAX_UINT256, MAX_UINT256, false, bytes(""));
+
+        uint256[] memory lastVirtualBalancesAfterSwap = ReClammPoolMock(pool).getLastVirtualBalances();
+
+        assertEq(
+            lastVirtualBalancesAfterSwap[daiIdx],
+            currentVirtualBalances[daiIdx],
+            "DAI virtual balance does not match"
+        );
+        assertEq(
+            lastVirtualBalancesAfterSwap[usdcIdx],
+            currentVirtualBalances[usdcIdx],
+            "USDC virtual balance does not match"
+        );
+
+        assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
+    }
 }

--- a/test/foundry/ReClammSwap.t.sol
+++ b/test/foundry/ReClammSwap.t.sol
@@ -21,7 +21,6 @@ contract ReClammSwapTest is BaseReClammTest {
         // Set the last timestamp.
         ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
 
-        // Wait 6 hours.
         vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
@@ -42,8 +41,8 @@ contract ReClammSwapTest is BaseReClammTest {
             (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2
         );
 
-        // Make a swap so the variable lastVirtualBalances is updated with the current virtual balances, and last
-        // timestamp is updated.
+        // Make a swap so that `lastVirtualBalances` is updated to match the current virtual balances.
+        // The last timestamp should also be updated to the current block.
         vm.prank(alice);
         router.swapSingleTokenExactIn(pool, dai, usdc, amountDaiIn, 0, MAX_UINT256, false, bytes(""));
 
@@ -62,7 +61,6 @@ contract ReClammSwapTest is BaseReClammTest {
         vm.prank(admin);
         ReClammPool(pool).setPriceRatioState(newFourthRootPriceRatio, block.timestamp, block.timestamp + 1 days);
 
-        // Wait 6 hours.
         vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
@@ -79,8 +77,8 @@ contract ReClammSwapTest is BaseReClammTest {
             (poolInitAmount - _MIN_TOKEN_BALANCE) / 2
         );
 
-        // Make a swap so the variable lastVirtualBalances is updated with the current virtual balances, and last
-        // timestamp is updated.
+        // Make a swap so that `lastVirtualBalances` is updated to match the current virtual balances.
+        // The last timestamp should also be updated to the current block.
         vm.prank(alice);
         router.swapSingleTokenExactIn(pool, dai, usdc, amountDaiIn, 0, MAX_UINT256, false, bytes(""));
 
@@ -106,7 +104,6 @@ contract ReClammSwapTest is BaseReClammTest {
         vm.prank(admin);
         ReClammPool(pool).setPriceRatioState(newFourthRootPriceRatio, block.timestamp, block.timestamp + 1 days);
 
-        // Wait 6 hours.
         vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
@@ -127,8 +124,8 @@ contract ReClammSwapTest is BaseReClammTest {
             (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2
         );
 
-        // Make a swap so the variable lastVirtualBalances is updated with the current virtual balances, and last
-        // timestamp is updated.
+        // Make a swap so that `lastVirtualBalances` is updated to match the current virtual balances.
+        // The last timestamp should also be updated to the current block.
         vm.prank(alice);
         router.swapSingleTokenExactIn(pool, dai, usdc, amountDaiIn, 0, MAX_UINT256, false, bytes(""));
 
@@ -146,7 +143,6 @@ contract ReClammSwapTest is BaseReClammTest {
         // Set the last timestamp.
         ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
 
-        // Wait 6 hours.
         vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
@@ -165,8 +161,8 @@ contract ReClammSwapTest is BaseReClammTest {
             (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2
         );
 
-        // Make a swap so the variable lastVirtualBalances is updated with the current virtual balances, and last
-        // timestamp is updated.
+        // Make a swap so that `lastVirtualBalances` is updated to match the current virtual balances.
+        // The last timestamp should also be updated to the current block.
         vm.prank(alice);
         router.swapSingleTokenExactIn(pool, dai, usdc, amountDaiIn, 0, MAX_UINT256, false, bytes(""));
 
@@ -184,7 +180,6 @@ contract ReClammSwapTest is BaseReClammTest {
         // Set the last timestamp.
         ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
 
-        // Wait 6 hours.
         vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
@@ -199,8 +194,8 @@ contract ReClammSwapTest is BaseReClammTest {
 
         uint256 amountUsdcOut = (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2;
 
-        // Make a swap so the variable lastVirtualBalances is updated with the current virtual balances, and last
-        // timestamp is updated.
+        // Make a swap so that `lastVirtualBalances` is updated to match the current virtual balances.
+        // The last timestamp should also be updated to the current block.
         vm.prank(alice);
         router.swapSingleTokenExactOut(pool, dai, usdc, amountUsdcOut, MAX_UINT256, MAX_UINT256, false, bytes(""));
 
@@ -219,7 +214,6 @@ contract ReClammSwapTest is BaseReClammTest {
         vm.prank(admin);
         ReClammPool(pool).setPriceRatioState(newFourthRootPriceRatio, block.timestamp, block.timestamp + 1 days);
 
-        // Wait 6 hours.
         vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
@@ -230,8 +224,8 @@ contract ReClammSwapTest is BaseReClammTest {
 
         uint256 amountUsdcOut = (poolInitAmount - _MIN_TOKEN_BALANCE) / 2;
 
-        // Make a swap so the variable lastVirtualBalances is updated with the current virtual balances, and last
-        // timestamp is updated.
+        // Make a swap so that `lastVirtualBalances` is updated to match the current virtual balances.
+        // The last timestamp should also be updated to the current block.
         vm.prank(alice);
         router.swapSingleTokenExactOut(pool, dai, usdc, amountUsdcOut, MAX_UINT256, MAX_UINT256, false, bytes(""));
 
@@ -257,7 +251,6 @@ contract ReClammSwapTest is BaseReClammTest {
         vm.prank(admin);
         ReClammPool(pool).setPriceRatioState(newFourthRootPriceRatio, block.timestamp, block.timestamp + 1 days);
 
-        // Wait 6 hours.
         vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
@@ -272,8 +265,8 @@ contract ReClammSwapTest is BaseReClammTest {
 
         uint256 amountUsdcOut = (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2;
 
-        // Make a swap so the variable lastVirtualBalances is updated with the current virtual balances, and last
-        // timestamp is updated.
+        // Make a swap so that `lastVirtualBalances` is updated to match the current virtual balances.
+        // The last timestamp should also be updated to the current block.
         vm.prank(alice);
         router.swapSingleTokenExactOut(pool, dai, usdc, amountUsdcOut, MAX_UINT256, MAX_UINT256, false, bytes(""));
 
@@ -291,7 +284,6 @@ contract ReClammSwapTest is BaseReClammTest {
         // Set the last timestamp.
         ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
 
-        // Wait 6 hours.
         vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
@@ -304,8 +296,8 @@ contract ReClammSwapTest is BaseReClammTest {
 
         uint256 amountUsdcOut = (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2;
 
-        // Make a swap so the variable lastVirtualBalances is updated with the current virtual balances, and last
-        // timestamp is updated.
+        // Make a swap so that `lastVirtualBalances` is updated to match the current virtual balances.
+        // The last timestamp should also be updated to the current block.
         vm.prank(alice);
         router.swapSingleTokenExactOut(pool, dai, usdc, amountUsdcOut, MAX_UINT256, MAX_UINT256, false, bytes(""));
 

--- a/test/foundry/ReClammSwap.t.sol
+++ b/test/foundry/ReClammSwap.t.sol
@@ -32,16 +32,7 @@ contract ReClammSwapTest is BaseReClammTest {
         );
 
         // If the pool is out of range, the virtual balances should not match.
-        assertNotEq(
-            lastVirtualBalancesBeforeSwap[daiIdx],
-            currentVirtualBalances[daiIdx],
-            "DAI virtual balances match"
-        );
-        assertNotEq(
-            lastVirtualBalancesBeforeSwap[usdcIdx],
-            currentVirtualBalances[usdcIdx],
-            "USDC virtual balances match"
-        );
+        _assertVirtualBalancesDoNotMatch(lastVirtualBalancesBeforeSwap, currentVirtualBalances);
 
         uint256 amountDaiIn = ReClammMath.calculateInGivenOut(
             newBalances,
@@ -56,16 +47,7 @@ contract ReClammSwapTest is BaseReClammTest {
 
         uint256[] memory lastVirtualBalancesAfterSwap = ReClammPoolMock(pool).getLastVirtualBalances();
 
-        assertEq(
-            lastVirtualBalancesAfterSwap[daiIdx],
-            currentVirtualBalances[daiIdx],
-            "DAI virtual balances do not match"
-        );
-        assertEq(
-            lastVirtualBalancesAfterSwap[usdcIdx],
-            currentVirtualBalances[usdcIdx],
-            "USDC virtual balances do not match"
-        );
+        _assertVirtualBalancesMatch(lastVirtualBalancesAfterSwap, currentVirtualBalances);
 
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
     }
@@ -85,16 +67,7 @@ contract ReClammSwapTest is BaseReClammTest {
         uint256[] memory currentVirtualBalances = ReClammPool(pool).getCurrentVirtualBalances();
 
         // If the price ratio is updating, the virtual balances should not match.
-        assertNotEq(
-            lastVirtualBalancesBeforeSwap[daiIdx],
-            currentVirtualBalances[daiIdx],
-            "DAI virtual balances match"
-        );
-        assertNotEq(
-            lastVirtualBalancesBeforeSwap[usdcIdx],
-            currentVirtualBalances[usdcIdx],
-            "USDC virtual balances match"
-        );
+        _assertVirtualBalancesDoNotMatch(lastVirtualBalancesBeforeSwap, currentVirtualBalances);
 
         uint256 amountDaiIn = ReClammMath.calculateInGivenOut(
             [poolInitAmount, poolInitAmount].toMemoryArray(),
@@ -109,16 +82,7 @@ contract ReClammSwapTest is BaseReClammTest {
 
         uint256[] memory lastVirtualBalancesAfterSwap = ReClammPoolMock(pool).getLastVirtualBalances();
 
-        assertEq(
-            lastVirtualBalancesAfterSwap[daiIdx],
-            currentVirtualBalances[daiIdx],
-            "DAI virtual balances do not match"
-        );
-        assertEq(
-            lastVirtualBalancesAfterSwap[usdcIdx],
-            currentVirtualBalances[usdcIdx],
-            "USDC virtual balances do not match"
-        );
+        _assertVirtualBalancesMatch(lastVirtualBalancesAfterSwap, currentVirtualBalances);
 
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
     }
@@ -149,16 +113,7 @@ contract ReClammSwapTest is BaseReClammTest {
         );
 
         // If the pool is out of range and price ratio is updating, the virtual balances should not match.
-        assertNotEq(
-            lastVirtualBalancesBeforeSwap[daiIdx],
-            currentVirtualBalances[daiIdx],
-            "DAI virtual balances match"
-        );
-        assertNotEq(
-            lastVirtualBalancesBeforeSwap[usdcIdx],
-            currentVirtualBalances[usdcIdx],
-            "USDC virtual balances match"
-        );
+        _assertVirtualBalancesDoNotMatch(lastVirtualBalancesBeforeSwap, currentVirtualBalances);
 
         uint256 amountDaiIn = ReClammMath.calculateInGivenOut(
             newBalances,
@@ -173,16 +128,7 @@ contract ReClammSwapTest is BaseReClammTest {
 
         uint256[] memory lastVirtualBalancesAfterSwap = ReClammPoolMock(pool).getLastVirtualBalances();
 
-        assertEq(
-            lastVirtualBalancesAfterSwap[daiIdx],
-            currentVirtualBalances[daiIdx],
-            "DAI virtual balances do not match"
-        );
-        assertEq(
-            lastVirtualBalancesAfterSwap[usdcIdx],
-            currentVirtualBalances[usdcIdx],
-            "USDC virtual balances do not match"
-        );
+        _assertVirtualBalancesMatch(lastVirtualBalancesAfterSwap, currentVirtualBalances);
 
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
     }
@@ -203,16 +149,7 @@ contract ReClammSwapTest is BaseReClammTest {
         vm.assume(ReClammMath.isPoolInRange(newBalances, lastVirtualBalancesBeforeSwap, _DEFAULT_CENTEREDNESS_MARGIN));
 
         // If the pool is in range, the virtual balances should match.
-        assertEq(
-            lastVirtualBalancesBeforeSwap[daiIdx],
-            currentVirtualBalances[daiIdx],
-            "DAI virtual balance are not matching"
-        );
-        assertEq(
-            lastVirtualBalancesBeforeSwap[usdcIdx],
-            currentVirtualBalances[usdcIdx],
-            "USDC virtual balance are not matching"
-        );
+        _assertVirtualBalancesMatch(lastVirtualBalancesBeforeSwap, currentVirtualBalances);
 
         uint256 amountDaiIn = ReClammMath.calculateInGivenOut(
             newBalances,
@@ -227,16 +164,7 @@ contract ReClammSwapTest is BaseReClammTest {
 
         uint256[] memory lastVirtualBalancesAfterSwap = ReClammPoolMock(pool).getLastVirtualBalances();
 
-        assertEq(
-            lastVirtualBalancesAfterSwap[daiIdx],
-            currentVirtualBalances[daiIdx],
-            "DAI virtual balances do not match"
-        );
-        assertEq(
-            lastVirtualBalancesAfterSwap[usdcIdx],
-            currentVirtualBalances[usdcIdx],
-            "USDC virtual balances do not match"
-        );
+        _assertVirtualBalancesMatch(lastVirtualBalancesAfterSwap, currentVirtualBalances);
 
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
     }
@@ -259,16 +187,7 @@ contract ReClammSwapTest is BaseReClammTest {
         );
 
         // If the pool is out of range, the virtual balances should not match.
-        assertNotEq(
-            lastVirtualBalancesBeforeSwap[daiIdx],
-            currentVirtualBalances[daiIdx],
-            "DAI virtual balances match"
-        );
-        assertNotEq(
-            lastVirtualBalancesBeforeSwap[usdcIdx],
-            currentVirtualBalances[usdcIdx],
-            "USDC virtual balances match"
-        );
+        _assertVirtualBalancesDoNotMatch(lastVirtualBalancesBeforeSwap, currentVirtualBalances);
 
         uint256 amountUsdcOut = (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2;
 
@@ -277,16 +196,7 @@ contract ReClammSwapTest is BaseReClammTest {
 
         uint256[] memory lastVirtualBalancesAfterSwap = ReClammPoolMock(pool).getLastVirtualBalances();
 
-        assertEq(
-            lastVirtualBalancesAfterSwap[daiIdx],
-            currentVirtualBalances[daiIdx],
-            "DAI virtual balances do not match"
-        );
-        assertEq(
-            lastVirtualBalancesAfterSwap[usdcIdx],
-            currentVirtualBalances[usdcIdx],
-            "USDC virtual balances do not match"
-        );
+        _assertVirtualBalancesMatch(lastVirtualBalancesAfterSwap, currentVirtualBalances);
 
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
     }
@@ -306,16 +216,7 @@ contract ReClammSwapTest is BaseReClammTest {
         uint256[] memory currentVirtualBalances = ReClammPool(pool).getCurrentVirtualBalances();
 
         // If the price ratio is updating, the virtual balances should not match.
-        assertNotEq(
-            lastVirtualBalancesBeforeSwap[daiIdx],
-            currentVirtualBalances[daiIdx],
-            "DAI virtual balances match"
-        );
-        assertNotEq(
-            lastVirtualBalancesBeforeSwap[usdcIdx],
-            currentVirtualBalances[usdcIdx],
-            "USDC virtual balances match"
-        );
+        _assertVirtualBalancesDoNotMatch(lastVirtualBalancesBeforeSwap, currentVirtualBalances);
 
         uint256 amountUsdcOut = (poolInitAmount - _MIN_TOKEN_BALANCE) / 2;
 
@@ -324,16 +225,7 @@ contract ReClammSwapTest is BaseReClammTest {
 
         uint256[] memory lastVirtualBalancesAfterSwap = ReClammPoolMock(pool).getLastVirtualBalances();
 
-        assertEq(
-            lastVirtualBalancesAfterSwap[daiIdx],
-            currentVirtualBalances[daiIdx],
-            "DAI virtual balances do not match"
-        );
-        assertEq(
-            lastVirtualBalancesAfterSwap[usdcIdx],
-            currentVirtualBalances[usdcIdx],
-            "USDC virtual balances do not match"
-        );
+        _assertVirtualBalancesMatch(lastVirtualBalancesAfterSwap, currentVirtualBalances);
 
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
     }
@@ -364,16 +256,7 @@ contract ReClammSwapTest is BaseReClammTest {
         );
 
         // If the pool is out of range and prices are updating, the virtual balances should not match.
-        assertNotEq(
-            lastVirtualBalancesBeforeSwap[daiIdx],
-            currentVirtualBalances[daiIdx],
-            "DAI virtual balances match"
-        );
-        assertNotEq(
-            lastVirtualBalancesBeforeSwap[usdcIdx],
-            currentVirtualBalances[usdcIdx],
-            "USDC virtual balances match"
-        );
+        _assertVirtualBalancesDoNotMatch(lastVirtualBalancesBeforeSwap, currentVirtualBalances);
 
         uint256 amountUsdcOut = (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2;
 
@@ -382,16 +265,7 @@ contract ReClammSwapTest is BaseReClammTest {
 
         uint256[] memory lastVirtualBalancesAfterSwap = ReClammPoolMock(pool).getLastVirtualBalances();
 
-        assertEq(
-            lastVirtualBalancesAfterSwap[daiIdx],
-            currentVirtualBalances[daiIdx],
-            "DAI virtual balances do not match"
-        );
-        assertEq(
-            lastVirtualBalancesAfterSwap[usdcIdx],
-            currentVirtualBalances[usdcIdx],
-            "USDC virtual balances do not match"
-        );
+        _assertVirtualBalancesMatch(lastVirtualBalancesAfterSwap, currentVirtualBalances);
 
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
     }
@@ -412,16 +286,7 @@ contract ReClammSwapTest is BaseReClammTest {
         vm.assume(ReClammMath.isPoolInRange(newBalances, lastVirtualBalancesBeforeSwap, _DEFAULT_CENTEREDNESS_MARGIN));
 
         // If the pool is in range, the virtual balances should match.
-        assertEq(
-            lastVirtualBalancesBeforeSwap[daiIdx],
-            currentVirtualBalances[daiIdx],
-            "DAI virtual balance are not matching"
-        );
-        assertEq(
-            lastVirtualBalancesBeforeSwap[usdcIdx],
-            currentVirtualBalances[usdcIdx],
-            "USDC virtual balance are not matching"
-        );
+        _assertVirtualBalancesMatch(lastVirtualBalancesBeforeSwap, currentVirtualBalances);
 
         uint256 amountUsdcOut = (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2;
 
@@ -430,17 +295,23 @@ contract ReClammSwapTest is BaseReClammTest {
 
         uint256[] memory lastVirtualBalancesAfterSwap = ReClammPoolMock(pool).getLastVirtualBalances();
 
-        assertEq(
-            lastVirtualBalancesAfterSwap[daiIdx],
-            currentVirtualBalances[daiIdx],
-            "DAI virtual balances do not match"
-        );
-        assertEq(
-            lastVirtualBalancesAfterSwap[usdcIdx],
-            currentVirtualBalances[usdcIdx],
-            "USDC virtual balances do not match"
-        );
-
+        _assertVirtualBalancesMatch(lastVirtualBalancesAfterSwap, currentVirtualBalances);
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
+    }
+
+    function _assertVirtualBalancesMatch(
+        uint256[] memory virtualBalances1,
+        uint256[] memory virtualBalances2
+    ) internal view {
+        assertEq(virtualBalances1[daiIdx], virtualBalances2[daiIdx], "DAI virtual balances do not match");
+        assertEq(virtualBalances1[usdcIdx], virtualBalances2[usdcIdx], "USDC virtual balances do not match");
+    }
+
+    function _assertVirtualBalancesDoNotMatch(
+        uint256[] memory virtualBalances1,
+        uint256[] memory virtualBalances2
+    ) internal view {
+        assertNotEq(virtualBalances1[daiIdx], virtualBalances2[daiIdx], "DAI virtual balances match");
+        assertNotEq(virtualBalances1[usdcIdx], virtualBalances2[usdcIdx], "USDC virtual balances match");
     }
 }

--- a/test/foundry/ReClammSwap.t.sol
+++ b/test/foundry/ReClammSwap.t.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/test/ArrayHelpers.sol";
+
+import { ReClammPoolMock } from "../../contracts/test/ReClammPoolMock.sol";
+import { ReClammMath } from "../../contracts/lib/ReClammMath.sol";
+import { ReClammPool } from "../../contracts/ReClammPool.sol";
+import { BaseReClammTest } from "./utils/BaseReClammTest.sol";
+
+contract ReClammSwapTest is BaseReClammTest {
+    using ArrayHelpers for *;
+
+    function testSwapExactInOutOfRange__Fuzz(uint256 daiBalance, uint256 usdcBalance) public {
+        // Set the pool balances.
+        uint256[] memory newBalances = _setPoolBalances(daiBalance, usdcBalance);
+
+        // Set the last timestamp.
+        ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
+
+        // Pass 6 hours.
+        vm.warp(block.timestamp + 6 * 3600);
+
+        uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
+        uint256[] memory currentVirtualBalances = ReClammPool(pool).getCurrentVirtualBalances();
+
+        vm.assume(
+            ReClammMath.isPoolInRange(newBalances, lastVirtualBalancesBeforeSwap, _DEFAULT_CENTEREDNESS_MARGIN) == false
+        );
+
+        // If the pool is out of range, the virtual balances should not match.
+        assertNotEq(
+            lastVirtualBalancesBeforeSwap[daiIdx],
+            currentVirtualBalances[daiIdx],
+            "DAI virtual balance are matching"
+        );
+        assertNotEq(
+            lastVirtualBalancesBeforeSwap[usdcIdx],
+            currentVirtualBalances[usdcIdx],
+            "USDC virtual balance are matching"
+        );
+
+        uint256 amountDaiIn = ReClammMath.calculateInGivenOut(
+            newBalances,
+            currentVirtualBalances,
+            daiIdx,
+            usdcIdx,
+            (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2
+        );
+
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(pool, dai, usdc, amountDaiIn, 0, MAX_UINT256, false, bytes(""));
+
+        uint256[] memory lastVirtualBalancesAfterSwap = ReClammPoolMock(pool).getLastVirtualBalances();
+
+        assertEq(
+            lastVirtualBalancesAfterSwap[daiIdx],
+            currentVirtualBalances[daiIdx],
+            "DAI virtual balance does not match"
+        );
+        assertEq(
+            lastVirtualBalancesAfterSwap[usdcIdx],
+            currentVirtualBalances[usdcIdx],
+            "USDC virtual balance does not match"
+        );
+
+        assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
+    }
+
+    function testSwapExactInPriceRatioUpdating__Fuzz(uint256 newFourthRootPriceRatio) public {
+        uint256 currentFourthRootPriceRatio = ReClammPool(pool).getCurrentFourthRootPriceRatio();
+        newFourthRootPriceRatio = bound(newFourthRootPriceRatio, 1.1e18, 10e18);
+        vm.assume(currentFourthRootPriceRatio != newFourthRootPriceRatio);
+
+        vm.prank(admin);
+        ReClammPool(pool).setPriceRatioState(newFourthRootPriceRatio, block.timestamp, block.timestamp + 24 * 3600);
+
+        // Pass 6 hours.
+        vm.warp(block.timestamp + 6 * 3600);
+
+        uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
+        uint256[] memory currentVirtualBalances = ReClammPool(pool).getCurrentVirtualBalances();
+
+        // If the price ratio is updating, the virtual balances should not match.
+        assertNotEq(
+            lastVirtualBalancesBeforeSwap[daiIdx],
+            currentVirtualBalances[daiIdx],
+            "DAI virtual balance are matching"
+        );
+        assertNotEq(
+            lastVirtualBalancesBeforeSwap[usdcIdx],
+            currentVirtualBalances[usdcIdx],
+            "USDC virtual balance are matching"
+        );
+
+        uint256 amountDaiIn = ReClammMath.calculateInGivenOut(
+            [poolInitAmount, poolInitAmount].toMemoryArray(),
+            currentVirtualBalances,
+            daiIdx,
+            usdcIdx,
+            (poolInitAmount - _MIN_TOKEN_BALANCE) / 2
+        );
+
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(pool, dai, usdc, amountDaiIn, 0, MAX_UINT256, false, bytes(""));
+
+        uint256[] memory lastVirtualBalancesAfterSwap = ReClammPoolMock(pool).getLastVirtualBalances();
+
+        assertEq(
+            lastVirtualBalancesAfterSwap[daiIdx],
+            currentVirtualBalances[daiIdx],
+            "DAI virtual balance does not match"
+        );
+        assertEq(
+            lastVirtualBalancesAfterSwap[usdcIdx],
+            currentVirtualBalances[usdcIdx],
+            "USDC virtual balance does not match"
+        );
+
+        assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
+    }
+
+    function testSwapExactInInRange__Fuzz(uint256 daiBalance, uint256 usdcBalance) public {
+        // Set the pool balances.
+        uint256[] memory newBalances = _setPoolBalances(daiBalance, usdcBalance);
+
+        // Set the last timestamp.
+        ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
+
+        // Pass 6 hours.
+        vm.warp(block.timestamp + 6 * 3600);
+
+        uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
+        uint256[] memory currentVirtualBalances = ReClammPool(pool).getCurrentVirtualBalances();
+
+        vm.assume(ReClammMath.isPoolInRange(newBalances, lastVirtualBalancesBeforeSwap, _DEFAULT_CENTEREDNESS_MARGIN));
+
+        // If the pool is in range, the virtual balances should match.
+        assertEq(
+            lastVirtualBalancesBeforeSwap[daiIdx],
+            currentVirtualBalances[daiIdx],
+            "DAI virtual balance are not matching"
+        );
+        assertEq(
+            lastVirtualBalancesBeforeSwap[usdcIdx],
+            currentVirtualBalances[usdcIdx],
+            "USDC virtual balance are not matching"
+        );
+
+        uint256 amountDaiIn = ReClammMath.calculateInGivenOut(
+            newBalances,
+            currentVirtualBalances,
+            daiIdx,
+            usdcIdx,
+            (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2
+        );
+
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(pool, dai, usdc, amountDaiIn, 0, MAX_UINT256, false, bytes(""));
+
+        uint256[] memory lastVirtualBalancesAfterSwap = ReClammPoolMock(pool).getLastVirtualBalances();
+
+        assertEq(
+            lastVirtualBalancesAfterSwap[daiIdx],
+            currentVirtualBalances[daiIdx],
+            "DAI virtual balance does not match"
+        );
+        assertEq(
+            lastVirtualBalancesAfterSwap[usdcIdx],
+            currentVirtualBalances[usdcIdx],
+            "USDC virtual balance does not match"
+        );
+
+        assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
+    }
+}

--- a/test/foundry/ReClammSwap.t.sol
+++ b/test/foundry/ReClammSwap.t.sol
@@ -21,8 +21,8 @@ contract ReClammSwapTest is BaseReClammTest {
         // Set the last timestamp.
         ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
 
-        // Pass 6 hours.
-        vm.warp(block.timestamp + 6 * 3600);
+        // Wait 6 hours.
+        vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
         uint256[] memory currentVirtualBalances = ReClammPool(pool).getCurrentVirtualBalances();
@@ -76,10 +76,10 @@ contract ReClammSwapTest is BaseReClammTest {
         vm.assume(currentFourthRootPriceRatio != newFourthRootPriceRatio);
 
         vm.prank(admin);
-        ReClammPool(pool).setPriceRatioState(newFourthRootPriceRatio, block.timestamp, block.timestamp + 24 * 3600);
+        ReClammPool(pool).setPriceRatioState(newFourthRootPriceRatio, block.timestamp, block.timestamp + 1 days);
 
-        // Pass 6 hours.
-        vm.warp(block.timestamp + 6 * 3600);
+        // Wait 6 hours.
+        vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
         uint256[] memory currentVirtualBalances = ReClammPool(pool).getCurrentVirtualBalances();
@@ -136,10 +136,10 @@ contract ReClammSwapTest is BaseReClammTest {
         vm.assume(currentFourthRootPriceRatio != newFourthRootPriceRatio);
 
         vm.prank(admin);
-        ReClammPool(pool).setPriceRatioState(newFourthRootPriceRatio, block.timestamp, block.timestamp + 24 * 3600);
+        ReClammPool(pool).setPriceRatioState(newFourthRootPriceRatio, block.timestamp, block.timestamp + 1 days);
 
-        // Pass 6 hours.
-        vm.warp(block.timestamp + 6 * 3600);
+        // Wait 6 hours.
+        vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
         uint256[] memory currentVirtualBalances = ReClammPool(pool).getCurrentVirtualBalances();
@@ -194,8 +194,8 @@ contract ReClammSwapTest is BaseReClammTest {
         // Set the last timestamp.
         ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
 
-        // Pass 6 hours.
-        vm.warp(block.timestamp + 6 * 3600);
+        // Wait 6 hours.
+        vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
         uint256[] memory currentVirtualBalances = ReClammPool(pool).getCurrentVirtualBalances();
@@ -248,8 +248,8 @@ contract ReClammSwapTest is BaseReClammTest {
         // Set the last timestamp.
         ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
 
-        // Pass 6 hours.
-        vm.warp(block.timestamp + 6 * 3600);
+        // Wait 6 hours.
+        vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
         uint256[] memory currentVirtualBalances = ReClammPool(pool).getCurrentVirtualBalances();
@@ -297,10 +297,10 @@ contract ReClammSwapTest is BaseReClammTest {
         vm.assume(currentFourthRootPriceRatio != newFourthRootPriceRatio);
 
         vm.prank(admin);
-        ReClammPool(pool).setPriceRatioState(newFourthRootPriceRatio, block.timestamp, block.timestamp + 24 * 3600);
+        ReClammPool(pool).setPriceRatioState(newFourthRootPriceRatio, block.timestamp, block.timestamp + 1 days);
 
-        // Pass 6 hours.
-        vm.warp(block.timestamp + 6 * 3600);
+        // Wait 6 hours.
+        vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
         uint256[] memory currentVirtualBalances = ReClammPool(pool).getCurrentVirtualBalances();
@@ -351,10 +351,10 @@ contract ReClammSwapTest is BaseReClammTest {
         vm.assume(currentFourthRootPriceRatio != newFourthRootPriceRatio);
 
         vm.prank(admin);
-        ReClammPool(pool).setPriceRatioState(newFourthRootPriceRatio, block.timestamp, block.timestamp + 24 * 3600);
+        ReClammPool(pool).setPriceRatioState(newFourthRootPriceRatio, block.timestamp, block.timestamp + 1 days);
 
-        // Pass 6 hours.
-        vm.warp(block.timestamp + 6 * 3600);
+        // Wait 6 hours.
+        vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
         uint256[] memory currentVirtualBalances = ReClammPool(pool).getCurrentVirtualBalances();
@@ -403,8 +403,8 @@ contract ReClammSwapTest is BaseReClammTest {
         // Set the last timestamp.
         ReClammPoolMock(pool).setLastTimestamp(block.timestamp);
 
-        // Pass 6 hours.
-        vm.warp(block.timestamp + 6 * 3600);
+        // Wait 6 hours.
+        vm.warp(block.timestamp + 6 hours);
 
         uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
         uint256[] memory currentVirtualBalances = ReClammPool(pool).getCurrentVirtualBalances();

--- a/test/foundry/ReClammSwap.t.sol
+++ b/test/foundry/ReClammSwap.t.sol
@@ -319,7 +319,7 @@ contract ReClammSwapTest is BaseReClammTest {
         uint256[] memory virtualBalances1,
         uint256[] memory virtualBalances2
     ) internal view {
-        assertNotEq(virtualBalances1[daiIdx], virtualBalances2[daiIdx], "DAI virtual balances match");
-        assertNotEq(virtualBalances1[usdcIdx], virtualBalances2[usdcIdx], "USDC virtual balances match");
+        assertNotEq(virtualBalances1[daiIdx], virtualBalances2[daiIdx], "DAI virtual balances remain unchanged");
+        assertNotEq(virtualBalances1[usdcIdx], virtualBalances2[usdcIdx], "USDC virtual balances remain unchanged");
     }
 }

--- a/test/foundry/ReClammSwap.t.sol
+++ b/test/foundry/ReClammSwap.t.sol
@@ -14,7 +14,7 @@ import { BaseReClammTest } from "./utils/BaseReClammTest.sol";
 contract ReClammSwapTest is BaseReClammTest {
     using ArrayHelpers for *;
 
-    function testSwapExactInOutOfRange__Fuzz(uint256 daiBalance, uint256 usdcBalance) public {
+    function testOutOfRangeSwapExactIn__Fuzz(uint256 daiBalance, uint256 usdcBalance) public {
         // Set the pool balances.
         uint256[] memory newBalances = _setPoolBalances(daiBalance, usdcBalance);
 
@@ -70,7 +70,7 @@ contract ReClammSwapTest is BaseReClammTest {
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
     }
 
-    function testSwapExactInPriceRatioUpdating__Fuzz(uint256 newFourthRootPriceRatio) public {
+    function testInRangePriceRatioUpdatingSwapExactIn__Fuzz(uint256 newFourthRootPriceRatio) public {
         uint256 currentFourthRootPriceRatio = ReClammPool(pool).getCurrentFourthRootPriceRatio();
         newFourthRootPriceRatio = bound(newFourthRootPriceRatio, 1.1e18, 10e18);
         vm.assume(currentFourthRootPriceRatio != newFourthRootPriceRatio);
@@ -123,7 +123,7 @@ contract ReClammSwapTest is BaseReClammTest {
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
     }
 
-    function testSwapExactInPriceRatioUpdatingOutOfRange__Fuzz(
+    function testOutOfRangePriceRatioUpdatingSwapExactIn__Fuzz(
         uint256 daiBalance,
         uint256 usdcBalance,
         uint256 newFourthRootPriceRatio
@@ -187,7 +187,7 @@ contract ReClammSwapTest is BaseReClammTest {
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
     }
 
-    function testSwapExactInInRange__Fuzz(uint256 daiBalance, uint256 usdcBalance) public {
+    function testInRangeSwapExactIn__Fuzz(uint256 daiBalance, uint256 usdcBalance) public {
         // Set the pool balances.
         uint256[] memory newBalances = _setPoolBalances(daiBalance, usdcBalance);
 
@@ -241,7 +241,7 @@ contract ReClammSwapTest is BaseReClammTest {
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
     }
 
-    function testSwapExactOutOutOfRange__Fuzz(uint256 daiBalance, uint256 usdcBalance) public {
+    function testOutOfRangeSwapExactOut__Fuzz(uint256 daiBalance, uint256 usdcBalance) public {
         // Set the pool balances.
         uint256[] memory newBalances = _setPoolBalances(daiBalance, usdcBalance);
 
@@ -291,7 +291,7 @@ contract ReClammSwapTest is BaseReClammTest {
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
     }
 
-    function testSwapExactOutPriceRatioUpdating__Fuzz(uint256 newFourthRootPriceRatio) public {
+    function testInRangePriceRatioUpdatingSwapExactOut__Fuzz(uint256 newFourthRootPriceRatio) public {
         uint256 currentFourthRootPriceRatio = ReClammPool(pool).getCurrentFourthRootPriceRatio();
         newFourthRootPriceRatio = bound(newFourthRootPriceRatio, 1.1e18, 10e18);
         vm.assume(currentFourthRootPriceRatio != newFourthRootPriceRatio);
@@ -338,7 +338,7 @@ contract ReClammSwapTest is BaseReClammTest {
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
     }
 
-    function testSwapExactOutPriceRatioUpdatingOutOfRange__Fuzz(
+    function testOutOfRangePriceRatioUpdatingSwapExactOut__Fuzz(
         uint256 daiBalance,
         uint256 usdcBalance,
         uint256 newFourthRootPriceRatio
@@ -396,7 +396,7 @@ contract ReClammSwapTest is BaseReClammTest {
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
     }
 
-    function testSwapExactOutInRange__Fuzz(uint256 daiBalance, uint256 usdcBalance) public {
+    function testInRangeSwapExactOut__Fuzz(uint256 daiBalance, uint256 usdcBalance) public {
         // Set the pool balances.
         uint256[] memory newBalances = _setPoolBalances(daiBalance, usdcBalance);
 

--- a/test/foundry/ReClammSwap.t.sol
+++ b/test/foundry/ReClammSwap.t.sol
@@ -35,12 +35,12 @@ contract ReClammSwapTest is BaseReClammTest {
         assertNotEq(
             lastVirtualBalancesBeforeSwap[daiIdx],
             currentVirtualBalances[daiIdx],
-            "DAI virtual balance are matching"
+            "DAI virtual balances match"
         );
         assertNotEq(
             lastVirtualBalancesBeforeSwap[usdcIdx],
             currentVirtualBalances[usdcIdx],
-            "USDC virtual balance are matching"
+            "USDC virtual balances match"
         );
 
         uint256 amountDaiIn = ReClammMath.calculateInGivenOut(
@@ -59,12 +59,12 @@ contract ReClammSwapTest is BaseReClammTest {
         assertEq(
             lastVirtualBalancesAfterSwap[daiIdx],
             currentVirtualBalances[daiIdx],
-            "DAI virtual balance does not match"
+            "DAI virtual balances do not match"
         );
         assertEq(
             lastVirtualBalancesAfterSwap[usdcIdx],
             currentVirtualBalances[usdcIdx],
-            "USDC virtual balance does not match"
+            "USDC virtual balances do not match"
         );
 
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
@@ -88,12 +88,12 @@ contract ReClammSwapTest is BaseReClammTest {
         assertNotEq(
             lastVirtualBalancesBeforeSwap[daiIdx],
             currentVirtualBalances[daiIdx],
-            "DAI virtual balance are matching"
+            "DAI virtual balances match"
         );
         assertNotEq(
             lastVirtualBalancesBeforeSwap[usdcIdx],
             currentVirtualBalances[usdcIdx],
-            "USDC virtual balance are matching"
+            "USDC virtual balances match"
         );
 
         uint256 amountDaiIn = ReClammMath.calculateInGivenOut(
@@ -112,12 +112,12 @@ contract ReClammSwapTest is BaseReClammTest {
         assertEq(
             lastVirtualBalancesAfterSwap[daiIdx],
             currentVirtualBalances[daiIdx],
-            "DAI virtual balance does not match"
+            "DAI virtual balances do not match"
         );
         assertEq(
             lastVirtualBalancesAfterSwap[usdcIdx],
             currentVirtualBalances[usdcIdx],
-            "USDC virtual balance does not match"
+            "USDC virtual balances do not match"
         );
 
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
@@ -152,12 +152,12 @@ contract ReClammSwapTest is BaseReClammTest {
         assertNotEq(
             lastVirtualBalancesBeforeSwap[daiIdx],
             currentVirtualBalances[daiIdx],
-            "DAI virtual balance are matching"
+            "DAI virtual balances match"
         );
         assertNotEq(
             lastVirtualBalancesBeforeSwap[usdcIdx],
             currentVirtualBalances[usdcIdx],
-            "USDC virtual balance are matching"
+            "USDC virtual balances match"
         );
 
         uint256 amountDaiIn = ReClammMath.calculateInGivenOut(
@@ -176,12 +176,12 @@ contract ReClammSwapTest is BaseReClammTest {
         assertEq(
             lastVirtualBalancesAfterSwap[daiIdx],
             currentVirtualBalances[daiIdx],
-            "DAI virtual balance does not match"
+            "DAI virtual balances do not match"
         );
         assertEq(
             lastVirtualBalancesAfterSwap[usdcIdx],
             currentVirtualBalances[usdcIdx],
-            "USDC virtual balance does not match"
+            "USDC virtual balances do not match"
         );
 
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
@@ -230,12 +230,12 @@ contract ReClammSwapTest is BaseReClammTest {
         assertEq(
             lastVirtualBalancesAfterSwap[daiIdx],
             currentVirtualBalances[daiIdx],
-            "DAI virtual balance does not match"
+            "DAI virtual balances do not match"
         );
         assertEq(
             lastVirtualBalancesAfterSwap[usdcIdx],
             currentVirtualBalances[usdcIdx],
-            "USDC virtual balance does not match"
+            "USDC virtual balances do not match"
         );
 
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
@@ -262,12 +262,12 @@ contract ReClammSwapTest is BaseReClammTest {
         assertNotEq(
             lastVirtualBalancesBeforeSwap[daiIdx],
             currentVirtualBalances[daiIdx],
-            "DAI virtual balance are matching"
+            "DAI virtual balances match"
         );
         assertNotEq(
             lastVirtualBalancesBeforeSwap[usdcIdx],
             currentVirtualBalances[usdcIdx],
-            "USDC virtual balance are matching"
+            "USDC virtual balances match"
         );
 
         uint256 amountUsdcOut = (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2;
@@ -280,12 +280,12 @@ contract ReClammSwapTest is BaseReClammTest {
         assertEq(
             lastVirtualBalancesAfterSwap[daiIdx],
             currentVirtualBalances[daiIdx],
-            "DAI virtual balance does not match"
+            "DAI virtual balances do not match"
         );
         assertEq(
             lastVirtualBalancesAfterSwap[usdcIdx],
             currentVirtualBalances[usdcIdx],
-            "USDC virtual balance does not match"
+            "USDC virtual balances do not match"
         );
 
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
@@ -309,12 +309,12 @@ contract ReClammSwapTest is BaseReClammTest {
         assertNotEq(
             lastVirtualBalancesBeforeSwap[daiIdx],
             currentVirtualBalances[daiIdx],
-            "DAI virtual balance are matching"
+            "DAI virtual balances match"
         );
         assertNotEq(
             lastVirtualBalancesBeforeSwap[usdcIdx],
             currentVirtualBalances[usdcIdx],
-            "USDC virtual balance are matching"
+            "USDC virtual balances match"
         );
 
         uint256 amountUsdcOut = (poolInitAmount - _MIN_TOKEN_BALANCE) / 2;
@@ -327,12 +327,12 @@ contract ReClammSwapTest is BaseReClammTest {
         assertEq(
             lastVirtualBalancesAfterSwap[daiIdx],
             currentVirtualBalances[daiIdx],
-            "DAI virtual balance does not match"
+            "DAI virtual balances do not match"
         );
         assertEq(
             lastVirtualBalancesAfterSwap[usdcIdx],
             currentVirtualBalances[usdcIdx],
-            "USDC virtual balance does not match"
+            "USDC virtual balances do not match"
         );
 
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
@@ -367,12 +367,12 @@ contract ReClammSwapTest is BaseReClammTest {
         assertNotEq(
             lastVirtualBalancesBeforeSwap[daiIdx],
             currentVirtualBalances[daiIdx],
-            "DAI virtual balance are matching"
+            "DAI virtual balances match"
         );
         assertNotEq(
             lastVirtualBalancesBeforeSwap[usdcIdx],
             currentVirtualBalances[usdcIdx],
-            "USDC virtual balance are matching"
+            "USDC virtual balances match"
         );
 
         uint256 amountUsdcOut = (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2;
@@ -385,12 +385,12 @@ contract ReClammSwapTest is BaseReClammTest {
         assertEq(
             lastVirtualBalancesAfterSwap[daiIdx],
             currentVirtualBalances[daiIdx],
-            "DAI virtual balance does not match"
+            "DAI virtual balances do not match"
         );
         assertEq(
             lastVirtualBalancesAfterSwap[usdcIdx],
             currentVirtualBalances[usdcIdx],
-            "USDC virtual balance does not match"
+            "USDC virtual balances do not match"
         );
 
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
@@ -433,12 +433,12 @@ contract ReClammSwapTest is BaseReClammTest {
         assertEq(
             lastVirtualBalancesAfterSwap[daiIdx],
             currentVirtualBalances[daiIdx],
-            "DAI virtual balance does not match"
+            "DAI virtual balances do not match"
         );
         assertEq(
             lastVirtualBalancesAfterSwap[usdcIdx],
             currentVirtualBalances[usdcIdx],
-            "USDC virtual balance does not match"
+            "USDC virtual balances do not match"
         );
 
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");

--- a/test/foundry/ReClammSwap.t.sol
+++ b/test/foundry/ReClammSwap.t.sol
@@ -123,6 +123,70 @@ contract ReClammSwapTest is BaseReClammTest {
         assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
     }
 
+    function testSwapExactInPriceRatioUpdatingOutOfRange__Fuzz(
+        uint256 daiBalance,
+        uint256 usdcBalance,
+        uint256 newFourthRootPriceRatio
+    ) public {
+        // Set the pool balances.
+        uint256[] memory newBalances = _setPoolBalances(daiBalance, usdcBalance);
+
+        uint256 currentFourthRootPriceRatio = ReClammPool(pool).getCurrentFourthRootPriceRatio();
+        newFourthRootPriceRatio = bound(newFourthRootPriceRatio, 1.1e18, 10e18);
+        vm.assume(currentFourthRootPriceRatio != newFourthRootPriceRatio);
+
+        vm.prank(admin);
+        ReClammPool(pool).setPriceRatioState(newFourthRootPriceRatio, block.timestamp, block.timestamp + 24 * 3600);
+
+        // Pass 6 hours.
+        vm.warp(block.timestamp + 6 * 3600);
+
+        uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
+        uint256[] memory currentVirtualBalances = ReClammPool(pool).getCurrentVirtualBalances();
+
+        vm.assume(
+            ReClammMath.isPoolInRange(newBalances, lastVirtualBalancesBeforeSwap, _DEFAULT_CENTEREDNESS_MARGIN) == false
+        );
+
+        // If the pool is out of range and price ratio is updating, the virtual balances should not match.
+        assertNotEq(
+            lastVirtualBalancesBeforeSwap[daiIdx],
+            currentVirtualBalances[daiIdx],
+            "DAI virtual balance are matching"
+        );
+        assertNotEq(
+            lastVirtualBalancesBeforeSwap[usdcIdx],
+            currentVirtualBalances[usdcIdx],
+            "USDC virtual balance are matching"
+        );
+
+        uint256 amountDaiIn = ReClammMath.calculateInGivenOut(
+            newBalances,
+            currentVirtualBalances,
+            daiIdx,
+            usdcIdx,
+            (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2
+        );
+
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(pool, dai, usdc, amountDaiIn, 0, MAX_UINT256, false, bytes(""));
+
+        uint256[] memory lastVirtualBalancesAfterSwap = ReClammPoolMock(pool).getLastVirtualBalances();
+
+        assertEq(
+            lastVirtualBalancesAfterSwap[daiIdx],
+            currentVirtualBalances[daiIdx],
+            "DAI virtual balance does not match"
+        );
+        assertEq(
+            lastVirtualBalancesAfterSwap[usdcIdx],
+            currentVirtualBalances[usdcIdx],
+            "USDC virtual balance does not match"
+        );
+
+        assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
+    }
+
     function testSwapExactInInRange__Fuzz(uint256 daiBalance, uint256 usdcBalance) public {
         // Set the pool balances.
         uint256[] memory newBalances = _setPoolBalances(daiBalance, usdcBalance);
@@ -254,6 +318,64 @@ contract ReClammSwapTest is BaseReClammTest {
         );
 
         uint256 amountUsdcOut = (poolInitAmount - _MIN_TOKEN_BALANCE) / 2;
+
+        vm.prank(alice);
+        router.swapSingleTokenExactOut(pool, dai, usdc, amountUsdcOut, MAX_UINT256, MAX_UINT256, false, bytes(""));
+
+        uint256[] memory lastVirtualBalancesAfterSwap = ReClammPoolMock(pool).getLastVirtualBalances();
+
+        assertEq(
+            lastVirtualBalancesAfterSwap[daiIdx],
+            currentVirtualBalances[daiIdx],
+            "DAI virtual balance does not match"
+        );
+        assertEq(
+            lastVirtualBalancesAfterSwap[usdcIdx],
+            currentVirtualBalances[usdcIdx],
+            "USDC virtual balance does not match"
+        );
+
+        assertEq(ReClammPool(pool).getLastTimestamp(), block.timestamp, "Last timestamp does not match");
+    }
+
+    function testSwapExactOutPriceRatioUpdatingOutOfRange__Fuzz(
+        uint256 daiBalance,
+        uint256 usdcBalance,
+        uint256 newFourthRootPriceRatio
+    ) public {
+        // Set the pool balances.
+        uint256[] memory newBalances = _setPoolBalances(daiBalance, usdcBalance);
+
+        uint256 currentFourthRootPriceRatio = ReClammPool(pool).getCurrentFourthRootPriceRatio();
+        newFourthRootPriceRatio = bound(newFourthRootPriceRatio, 1.1e18, 10e18);
+        vm.assume(currentFourthRootPriceRatio != newFourthRootPriceRatio);
+
+        vm.prank(admin);
+        ReClammPool(pool).setPriceRatioState(newFourthRootPriceRatio, block.timestamp, block.timestamp + 24 * 3600);
+
+        // Pass 6 hours.
+        vm.warp(block.timestamp + 6 * 3600);
+
+        uint256[] memory lastVirtualBalancesBeforeSwap = ReClammPoolMock(pool).getLastVirtualBalances();
+        uint256[] memory currentVirtualBalances = ReClammPool(pool).getCurrentVirtualBalances();
+
+        vm.assume(
+            ReClammMath.isPoolInRange(newBalances, lastVirtualBalancesBeforeSwap, _DEFAULT_CENTEREDNESS_MARGIN) == false
+        );
+
+        // If the pool is out of range and prices are updating, the virtual balances should not match.
+        assertNotEq(
+            lastVirtualBalancesBeforeSwap[daiIdx],
+            currentVirtualBalances[daiIdx],
+            "DAI virtual balance are matching"
+        );
+        assertNotEq(
+            lastVirtualBalancesBeforeSwap[usdcIdx],
+            currentVirtualBalances[usdcIdx],
+            "USDC virtual balance are matching"
+        );
+
+        uint256 amountUsdcOut = (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2;
 
         vm.prank(alice);
         router.swapSingleTokenExactOut(pool, dai, usdc, amountUsdcOut, MAX_UINT256, MAX_UINT256, false, bytes(""));

--- a/test/foundry/ReClammSwap.t.sol
+++ b/test/foundry/ReClammSwap.t.sol
@@ -42,6 +42,8 @@ contract ReClammSwapTest is BaseReClammTest {
             (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2
         );
 
+        // Make a swap so the variable lastVirtualBalances is updated with the current virtual balances, and last
+        // timestamp is updated.
         vm.prank(alice);
         router.swapSingleTokenExactIn(pool, dai, usdc, amountDaiIn, 0, MAX_UINT256, false, bytes(""));
 
@@ -77,6 +79,8 @@ contract ReClammSwapTest is BaseReClammTest {
             (poolInitAmount - _MIN_TOKEN_BALANCE) / 2
         );
 
+        // Make a swap so the variable lastVirtualBalances is updated with the current virtual balances, and last
+        // timestamp is updated.
         vm.prank(alice);
         router.swapSingleTokenExactIn(pool, dai, usdc, amountDaiIn, 0, MAX_UINT256, false, bytes(""));
 
@@ -123,6 +127,8 @@ contract ReClammSwapTest is BaseReClammTest {
             (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2
         );
 
+        // Make a swap so the variable lastVirtualBalances is updated with the current virtual balances, and last
+        // timestamp is updated.
         vm.prank(alice);
         router.swapSingleTokenExactIn(pool, dai, usdc, amountDaiIn, 0, MAX_UINT256, false, bytes(""));
 
@@ -159,6 +165,8 @@ contract ReClammSwapTest is BaseReClammTest {
             (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2
         );
 
+        // Make a swap so the variable lastVirtualBalances is updated with the current virtual balances, and last
+        // timestamp is updated.
         vm.prank(alice);
         router.swapSingleTokenExactIn(pool, dai, usdc, amountDaiIn, 0, MAX_UINT256, false, bytes(""));
 
@@ -191,6 +199,8 @@ contract ReClammSwapTest is BaseReClammTest {
 
         uint256 amountUsdcOut = (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2;
 
+        // Make a swap so the variable lastVirtualBalances is updated with the current virtual balances, and last
+        // timestamp is updated.
         vm.prank(alice);
         router.swapSingleTokenExactOut(pool, dai, usdc, amountUsdcOut, MAX_UINT256, MAX_UINT256, false, bytes(""));
 
@@ -220,6 +230,8 @@ contract ReClammSwapTest is BaseReClammTest {
 
         uint256 amountUsdcOut = (poolInitAmount - _MIN_TOKEN_BALANCE) / 2;
 
+        // Make a swap so the variable lastVirtualBalances is updated with the current virtual balances, and last
+        // timestamp is updated.
         vm.prank(alice);
         router.swapSingleTokenExactOut(pool, dai, usdc, amountUsdcOut, MAX_UINT256, MAX_UINT256, false, bytes(""));
 
@@ -260,6 +272,8 @@ contract ReClammSwapTest is BaseReClammTest {
 
         uint256 amountUsdcOut = (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2;
 
+        // Make a swap so the variable lastVirtualBalances is updated with the current virtual balances, and last
+        // timestamp is updated.
         vm.prank(alice);
         router.swapSingleTokenExactOut(pool, dai, usdc, amountUsdcOut, MAX_UINT256, MAX_UINT256, false, bytes(""));
 
@@ -290,6 +304,8 @@ contract ReClammSwapTest is BaseReClammTest {
 
         uint256 amountUsdcOut = (newBalances[usdcIdx] - _MIN_TOKEN_BALANCE) / 2;
 
+        // Make a swap so the variable lastVirtualBalances is updated with the current virtual balances, and last
+        // timestamp is updated.
         vm.prank(alice);
         router.swapSingleTokenExactOut(pool, dai, usdc, amountUsdcOut, MAX_UINT256, MAX_UINT256, false, bytes(""));
 


### PR DESCRIPTION
# Description

Check whether Swap Exact In and Swap Exact Out update last timestamp and virtual balances correctly. The following scenarios are checked for Exact In/out:

* Pool In Range
* Pool Out of Range
* Pool updating price ratio
* Pool Out of Range and Updating price ratio

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [x] Tests

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #42 