### PR TITLE
Disables BPT rate for ReClamm Pools

### DIFF
--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -278,6 +278,11 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
         return 0;
     }
 
+    /// @inheritdoc IRateProvider
+    function getRate() public pure override returns (uint256) {
+        revert ReClammPoolBptRateUnsupported();
+    }
+
     /// @inheritdoc IReClammPool
     function getCurrentVirtualBalances() external view returns (uint256[] memory currentVirtualBalances) {
         (, , , uint256[] memory balancesScaled18) = _vault.getPoolTokenInfo(address(this));

--- a/contracts/interfaces/IReClammPool.sol
+++ b/contracts/interfaces/IReClammPool.sol
@@ -36,6 +36,14 @@ interface IReClammPool is IBasePool {
     /// @dev The pool is out of range before or after the operation.
     error PoolIsOutOfRange();
 
+    /**
+     * @notice `getRate` from `IRateProvider` was called on a ReClamm Pool.
+     * @dev ReClamm Pools should never be nested. This is because the invariant of the pool is used only to calculate
+     * swaps. However, when tracking the market price or shrinking/expanding the liquidity concentration, the invariant
+     * can decrease/increase, which makes the BPT rate meaningless.
+     */
+    error ReClammPoolBptRateUnsupported();
+
     /// @notice The Price Ratio State was updated.
     event PriceRatioStateUpdated(
         uint256 startFourthRootPriceRatio,

--- a/test/foundry/ReClammPool.t.sol
+++ b/test/foundry/ReClammPool.t.sol
@@ -55,6 +55,11 @@ contract ReClammPoolTest is BaseReClammTest {
         assertEq(fourthRootPriceRatio, endFourthRootPriceRatio, "FourthRootPriceRatio does not match new value");
     }
 
+    function testGetRate() public {
+        vm.expectRevert(IReClammPool.ReClammPoolBptRateUnsupported.selector);
+        ReClammPool(pool).getRate();
+    }
+
     function testSetPriceShiftDailyRate() public {
         uint256 newPriceShiftDailyRate = 200e16;
         vm.prank(admin);


### PR DESCRIPTION
# Description

ReClamm Pools should never be nested, as their invariant is used solely for swap calculations.

Retrieving a BPT rate from a ReClamm Pool is unsupported. This change explicitly disables the `getRate` function to prevent incorrect usage.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #57 