### PR TITLE
Create and initialize ReClamm pools using price interval and price target

### DIFF
--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -365,7 +365,7 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
     }
 
     /// @inheritdoc IReClammPool
-    function getTimeConstant() external view returns (uint256) {
+    function getPriceShiftDailyRateInSeconds() external view returns (uint256) {
         return _priceShiftDailyRangeInSeconds;
     }
 

--- a/contracts/ReClammPoolFactory.sol
+++ b/contracts/ReClammPoolFactory.sol
@@ -42,8 +42,10 @@ contract ReClammPoolFactory is IPoolVersion, BasePoolFactory, Version {
      * @param name The name of the pool
      * @param symbol The symbol of the pool
      * @param tokens An array of descriptors for the tokens the pool will manage
+     * @param initialMinPrice The initial minimum price of the pool
+     * @param initialMaxPrice The initial maximum price of the pool
+     * @param initialTargetPrice The initial target price of the pool
      * @param priceShiftDailyRate The allowed change in a virtual balance per day
-     * @param fourthRootPriceRatio The fourth root of the price ratio
      * @param centerednessMargin How far the price can be from the center before the price range starts to move
      * @param roleAccounts Addresses the Vault will allow to change certain pool settings
      * @param swapFeePercentage Initial swap fee percentage
@@ -55,8 +57,10 @@ contract ReClammPoolFactory is IPoolVersion, BasePoolFactory, Version {
         TokenConfig[] memory tokens,
         PoolRoleAccounts memory roleAccounts,
         uint256 swapFeePercentage,
+        uint256 initialMinPrice,
+        uint256 initialMaxPrice,
+        uint256 initialTargetPrice,
         uint256 priceShiftDailyRate,
-        uint96 fourthRootPriceRatio,
         uint64 centerednessMargin,
         bytes32 salt
     ) external returns (address pool) {
@@ -79,8 +83,10 @@ contract ReClammPoolFactory is IPoolVersion, BasePoolFactory, Version {
                     name: name,
                     symbol: symbol,
                     version: _poolVersion,
+                    initialMinPrice: initialMinPrice,
+                    initialMaxPrice: initialMaxPrice,
+                    initialTargetPrice: initialTargetPrice,
                     priceShiftDailyRate: priceShiftDailyRate,
-                    fourthRootPriceRatio: fourthRootPriceRatio,
                     centerednessMargin: centerednessMargin
                 }),
                 getVault()

--- a/contracts/interfaces/IReClammPool.sol
+++ b/contracts/interfaces/IReClammPool.sol
@@ -207,7 +207,7 @@ interface IReClammPool is IBasePool {
      * @dev The time constant is an internal representation of the raw price shift daily rate, expressed in seconds.
      * @return priceShiftDailyRangeInSeconds The time constant
      */
-    function getTimeConstant() external view returns (uint256 priceShiftDailyRangeInSeconds);
+    function getPriceShiftDailyRateInSeconds() external view returns (uint256 priceShiftDailyRangeInSeconds);
 
     /**
      * @notice Returns the current price ratio state.

--- a/contracts/lib/ReClammMath.sol
+++ b/contracts/lib/ReClammMath.sol
@@ -191,7 +191,7 @@ library ReClammMath {
         realBalances = new uint256[](2);
         realBalances[1] =
             Math.sqrt(
-                targetPrice.mulDown(virtualBalances[1]).mulDown(_INITIALIZATION_MAX_BALANCE_A + virtualBalances[0]) *
+                targetPrice.mulUp(virtualBalances[1]).mulUp(_INITIALIZATION_MAX_BALANCE_A + virtualBalances[0]) *
                     FixedPoint.ONE
             ) -
             virtualBalances[1];

--- a/contracts/test/ReClammMathMock.sol
+++ b/contracts/test/ReClammMathMock.sol
@@ -74,11 +74,16 @@ contract ReClammMathMock {
             );
     }
 
-    function initializeVirtualBalances(
-        uint256[] memory balancesScaled18,
-        uint256 fourthRootPriceRatio
-    ) external pure returns (uint256[] memory virtualBalances) {
-        return ReClammMath.initializeVirtualBalances(balancesScaled18, fourthRootPriceRatio);
+    function getTheoreticalPriceRatioAndBalances(
+        uint256 minPrice,
+        uint256 maxPrice,
+        uint256 targetPrice
+    )
+        external
+        pure
+        returns (uint256[] memory realBalances, uint256[] memory virtualBalances, uint256 fourthRootPriceRatio)
+    {
+        return ReClammMath.getTheoreticalPriceRatioAndBalances(minPrice, maxPrice, targetPrice);
     }
 
     function getCurrentVirtualBalances(

--- a/contracts/test/ReClammPoolFactoryMock.sol
+++ b/contracts/test/ReClammPoolFactoryMock.sol
@@ -40,8 +40,10 @@ contract ReClammPoolFactoryMock is IPoolVersion, BasePoolFactory, Version {
      * @param name The name of the pool
      * @param symbol The symbol of the pool
      * @param tokens An array of descriptors for the tokens the pool will manage
+     * @param initialMinPrice The initial minimum price of the pool
+     * @param initialMaxPrice The initial maximum price of the pool
+     * @param initialTargetPrice The initial target price of the pool
      * @param priceShiftDailyRate The allowed change in a virtual balance per day
-     * @param fourthRootPriceRatio The fourth root of the price ratio
      * @param centerednessMargin How far the price can be from the center before the price range starts to move
      * @param roleAccounts Addresses the Vault will allow to change certain pool settings
      * @param swapFeePercentage Initial swap fee percentage
@@ -53,8 +55,10 @@ contract ReClammPoolFactoryMock is IPoolVersion, BasePoolFactory, Version {
         TokenConfig[] memory tokens,
         PoolRoleAccounts memory roleAccounts,
         uint256 swapFeePercentage,
+        uint256 initialMinPrice,
+        uint256 initialMaxPrice,
+        uint256 initialTargetPrice,
         uint256 priceShiftDailyRate,
-        uint96 fourthRootPriceRatio,
         uint64 centerednessMargin,
         bytes32 salt
     ) external returns (address pool) {
@@ -77,8 +81,10 @@ contract ReClammPoolFactoryMock is IPoolVersion, BasePoolFactory, Version {
                     name: name,
                     symbol: symbol,
                     version: _poolVersion,
+                    initialMinPrice: initialMinPrice,
+                    initialMaxPrice: initialMaxPrice,
+                    initialTargetPrice: initialTargetPrice,
                     priceShiftDailyRate: priceShiftDailyRate,
-                    fourthRootPriceRatio: fourthRootPriceRatio,
                     centerednessMargin: centerednessMargin
                 }),
                 getVault()

--- a/test/foundry/E2eBatchSwapReClamm.t.sol
+++ b/test/foundry/E2eBatchSwapReClamm.t.sol
@@ -4,19 +4,39 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 
-import { IRateProvider } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IRateProvider.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 import { ERC20TestToken } from "@balancer-labs/v3-solidity-utils/contracts/test/ERC20TestToken.sol";
+import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
 import { E2eBatchSwapTest } from "@balancer-labs/v3-vault/test/foundry/E2eBatchSwap.t.sol";
 
 import { ReClammPoolContractsDeployer } from "./utils/ReClammPoolContractsDeployer.sol";
+import { ReClammPool } from "../../contracts/ReClammPool.sol";
 
 contract E2eBatchSwapReClammTest is E2eBatchSwapTest, ReClammPoolContractsDeployer {
+    using FixedPoint for uint256;
+
     /// @notice Overrides BaseVaultTest _createPool(). This pool is used by E2eBatchSwapTest tests.
     function _createPool(
         address[] memory tokens,
         string memory label
     ) internal override returns (address, bytes memory) {
         return createReClammPool(tokens, label, vault, lp);
+    }
+
+    function _initPool(
+        address poolToInit,
+        uint256[] memory amountsIn,
+        uint256 minBptOut
+    ) internal override returns (uint256) {
+        (IERC20[] memory tokens, , , ) = vault.getPoolTokenInfo(poolToInit);
+        uint256 proportion = ReClammPool(poolToInit).getInitializationProportion();
+
+        uint256[] memory initialBalances = new uint256[](2);
+        initialBalances[0] = amountsIn[0];
+        initialBalances[1] = amountsIn[0].mulDown(proportion);
+
+        return router.initialize(poolToInit, tokens, initialBalances, minBptOut, false, bytes(""));
     }
 
     function _setUpVariables() internal override {

--- a/test/foundry/E2eSwapReClamm.t.sol
+++ b/test/foundry/E2eSwapReClamm.t.sol
@@ -4,13 +4,18 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 
-import { IRateProvider } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IRateProvider.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 import { ERC20TestToken } from "@balancer-labs/v3-solidity-utils/contracts/test/ERC20TestToken.sol";
+import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
 import { E2eSwapTest } from "@balancer-labs/v3-vault/test/foundry/E2eSwap.t.sol";
 
 import { ReClammPoolContractsDeployer } from "./utils/ReClammPoolContractsDeployer.sol";
+import { ReClammPool } from "../../contracts/ReClammPool.sol";
 
 contract E2eSwapReClammTest is E2eSwapTest, ReClammPoolContractsDeployer {
+    using FixedPoint for uint256;
+
     function setUp() public override {
         E2eSwapTest.setUp();
     }
@@ -35,5 +40,20 @@ contract E2eSwapReClammTest is E2eSwapTest, ReClammPoolContractsDeployer {
         string memory label
     ) internal override returns (address newPool, bytes memory poolArgs) {
         return createReClammPool(tokens, label, vault, lp);
+    }
+
+    function _initPool(
+        address poolToInit,
+        uint256[] memory amountsIn,
+        uint256 minBptOut
+    ) internal override returns (uint256) {
+        (IERC20[] memory tokens, , , ) = vault.getPoolTokenInfo(poolToInit);
+        uint256 proportion = ReClammPool(poolToInit).getInitializationProportion();
+
+        uint256[] memory initialBalances = new uint256[](2);
+        initialBalances[0] = amountsIn[0];
+        initialBalances[1] = amountsIn[0].mulDown(proportion);
+
+        return router.initialize(poolToInit, tokens, initialBalances, minBptOut, false, bytes(""));
     }
 }

--- a/test/foundry/ReClammLiquidity.t.sol
+++ b/test/foundry/ReClammLiquidity.t.sol
@@ -15,7 +15,7 @@ import { ReClammPool } from "../../contracts/ReClammPool.sol";
 contract ReClammLiquidityTest is BaseReClammTest {
     using FixedPoint for uint256;
 
-    uint256 constant _MAX_PRICE_ERROR_ABS = 5;
+    uint256 constant _MAX_PRICE_ERROR_ABS = 2e4;
     uint256 constant _MAX_CENTEREDNESS_ERROR_ABS = 1e4;
 
     function testAddLiquidity__Fuzz(

--- a/test/foundry/ReClammMath.t.sol
+++ b/test/foundry/ReClammMath.t.sol
@@ -43,36 +43,6 @@ contract ReClammMathTest is BaseReClammTest {
         );
     }
 
-    function testInitializeVirtualBalances__Fuzz(
-        uint256 balance0,
-        uint256 balance1,
-        uint96 fourthRootPriceRatio
-    ) public pure {
-        balance0 = bound(balance0, 0, _MAX_TOKEN_BALANCE);
-        balance1 = bound(balance1, 0, _MAX_TOKEN_BALANCE);
-        fourthRootPriceRatio = SafeCast.toUint96(bound(fourthRootPriceRatio, FixedPoint.ONE + 1, type(uint96).max));
-
-        uint256[] memory balancesScaled18 = new uint256[](2);
-        balancesScaled18[0] = balance0;
-        balancesScaled18[1] = balance1;
-
-        uint256[] memory virtualBalances = ReClammMath.initializeVirtualBalances(
-            balancesScaled18,
-            fourthRootPriceRatio
-        );
-
-        assertEq(
-            virtualBalances[0],
-            balance0.divDown(fourthRootPriceRatio - FixedPoint.ONE),
-            "Virtual balance 0 should be correct"
-        );
-        assertEq(
-            virtualBalances[1],
-            balance1.divDown(fourthRootPriceRatio - FixedPoint.ONE),
-            "Virtual balance 1 should be correct"
-        );
-    }
-
     function testCalculateInGivenOut__Fuzz(
         uint256 balanceA,
         uint256 balanceB,

--- a/test/foundry/ReClammPool.t.sol
+++ b/test/foundry/ReClammPool.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import { IAuthentication } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
 import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
@@ -26,7 +27,7 @@ contract ReClammPoolTest is BaseReClammTest {
 
     function testGetCurrentFourthRootPriceRatio() public view {
         uint256 fourthRootPriceRatio = ReClammPool(pool).getCurrentFourthRootPriceRatio();
-        assertEq(fourthRootPriceRatio, _DEFAULT_FOURTH_ROOT_PRICE_RATIO, "Invalid default fourthRootPriceRatio");
+        assertEq(fourthRootPriceRatio, defaultFourthRootPriceRatio, "Invalid default fourthRootPriceRatio");
     }
 
     function testGetCenterednessMargin() public {
@@ -79,12 +80,12 @@ contract ReClammPoolTest is BaseReClammTest {
         PriceRatioState memory priceRatioState = ReClammPool(pool).getPriceRatioState();
         assertEq(
             priceRatioState.startFourthRootPriceRatio,
-            _DEFAULT_FOURTH_ROOT_PRICE_RATIO,
+            defaultFourthRootPriceRatio,
             "Invalid default startFourthRootPriceRatio"
         );
         assertEq(
             priceRatioState.endFourthRootPriceRatio,
-            _DEFAULT_FOURTH_ROOT_PRICE_RATIO,
+            defaultFourthRootPriceRatio,
             "Invalid default endFourthRootPriceRatio"
         );
         assertEq(priceRatioState.priceRatioUpdateStartTime, 0, "Invalid default priceRatioUpdateStartTime");

--- a/test/foundry/ReClammPool.t.sol
+++ b/test/foundry/ReClammPool.t.sol
@@ -67,14 +67,18 @@ contract ReClammPoolTest is BaseReClammTest {
         );
     }
 
-    function testGetTimeConstant() public {
+    function testGetPriceShiftDailyRateInSeconds() public {
         uint256 priceShiftDailyRate = 20e16;
-        uint256 expectedTimeConstant = ReClammMath.computePriceShiftDailyRate(priceShiftDailyRate);
+        uint256 expectedPriceShiftDailyRateInSeconds = ReClammMath.computePriceShiftDailyRate(priceShiftDailyRate);
         vm.prank(admin);
         ReClammPool(pool).setPriceShiftDailyRate(priceShiftDailyRate);
 
-        uint256 actualTimeConstant = ReClammPool(pool).getTimeConstant();
-        assertEq(actualTimeConstant, expectedTimeConstant, "Invalid priceShiftDailyRangeInSeconds");
+        uint256 actualPriceShiftDailyRateInSeconds = ReClammPool(pool).getPriceShiftDailyRateInSeconds();
+        assertEq(
+            actualPriceShiftDailyRateInSeconds,
+            expectedPriceShiftDailyRateInSeconds,
+            "Invalid priceShiftDailyRangeInSeconds"
+        );
     }
 
     function testGetPriceRatioState() public {

--- a/test/foundry/ReClammPoolVirtualBalances.t.sol
+++ b/test/foundry/ReClammPoolVirtualBalances.t.sol
@@ -20,130 +20,112 @@ contract ReClammPoolVirtualBalancesTest is BaseReClammTest {
     using FixedPoint for uint256;
     using ArrayHelpers for *;
 
-    uint256 private constant _PRICE_RATIO = 2e18; // Max price is 2x min price.
-    uint256 private constant _INITIAL_BALANCE_A = 1_000_000e18;
-    uint256 private constant _INITIAL_BALANCE_B = 100_000e18;
+    uint256 private constant _INITIAL_PARAMS_ERROR = 1e6;
 
     function setUp() public virtual override {
-        setPriceRatio(_PRICE_RATIO);
-        setInitialBalances(_INITIAL_BALANCE_A, _INITIAL_BALANCE_B);
         setPriceShiftDailyRate(0);
         super.setUp();
     }
 
     function testInitialParams() public view {
-        uint256[] memory virtualBalances = _calculateVirtualBalances();
+        (
+            uint256[] memory theoreticalBalances,
+            uint256[] memory theoreticalVirtualBalances,
+            uint256 theoreticalPriceRatio
+        ) = ReClammMath.getTheoreticalPriceRatioAndBalances(
+                _DEFAULT_MIN_PRICE,
+                _DEFAULT_MAX_PRICE,
+                _DEFAULT_TARGET_PRICE
+            );
 
-        (uint256[] memory curentVirtualBalances, ) = ReClammPool(pool).getCurrentVirtualBalances();
+        uint256 proportion = _initialBalances[0].divDown(theoreticalBalances[0]);
 
-        assertEq(
-            ReClammPool(pool).getCurrentFourthRootPriceRatio(),
-            fourthRootPriceRatio(),
-            "Invalid fourthRootPriceRatio"
+        assertEq(_initialFourthRootPriceRatio, theoreticalPriceRatio, "Invalid fourthRootPriceRatio");
+
+        // Don't need to check balances 0, since the proportion was calculated based on it.
+        assertApproxEqAbs(
+            _initialBalances[1],
+            theoreticalBalances[1].mulDown(proportion),
+            _INITIAL_PARAMS_ERROR,
+            "Invalid balance B"
         );
-        assertEq(curentVirtualBalances[0], virtualBalances[0], "Invalid virtual A balance");
-        assertEq(curentVirtualBalances[1], virtualBalances[1], "Invalid virtual B balance");
+
+        assertApproxEqAbs(
+            _initialVirtualBalances[0],
+            theoreticalVirtualBalances[0].mulDown(proportion),
+            _INITIAL_PARAMS_ERROR,
+            "Invalid virtual A balance"
+        );
+        assertApproxEqAbs(
+            _initialVirtualBalances[1],
+            theoreticalVirtualBalances[1].mulDown(proportion),
+            _INITIAL_PARAMS_ERROR,
+            "Invalid virtual B balance"
+        );
     }
 
-    function testWithDifferentInitialBalances__Fuzz(int256 diffCoefficient) public {
-        // This test verifies the virtual balances of two pools, where the real balances
-        // differ by a certain coefficient while maintaining the balance ratio.
-
-        diffCoefficient = bound(diffCoefficient, -100, 100);
-        if (diffCoefficient >= -1 && diffCoefficient <= 1) {
-            diffCoefficient = 2;
-        }
-
-        uint256[] memory newInitialBalances = new uint256[](2);
-        if (diffCoefficient > 0) {
-            newInitialBalances[0] = _INITIAL_BALANCE_A * uint256(diffCoefficient);
-            newInitialBalances[1] = _INITIAL_BALANCE_B * uint256(diffCoefficient);
-        } else {
-            newInitialBalances[0] = _INITIAL_BALANCE_A / uint256(-diffCoefficient);
-            newInitialBalances[1] = _INITIAL_BALANCE_B / uint256(-diffCoefficient);
-        }
-
-        setInitialBalances(newInitialBalances[0], newInitialBalances[1]);
-        (address firstPool, address secondPool) = _createNewPool();
-
-        assertEq(
-            ReClammPool(firstPool).getCurrentFourthRootPriceRatio(),
-            fourthRootPriceRatio(),
-            "Invalid fourthRootPriceRatio for firstPool"
-        );
-        assertEq(
-            ReClammPool(secondPool).getCurrentFourthRootPriceRatio(),
-            fourthRootPriceRatio(),
-            "Invalid fourthRootPriceRatio for newPool"
+    function testInitializationWithPrices__Fuzz(
+        uint256 newMinPrice,
+        uint256 newMaxPrice,
+        uint256 newTargetPrice
+    ) public {
+        newMinPrice = bound(newMinPrice, _MIN_PRICE, _MAX_PRICE.divDown(_MIN_PRICE_RATIO));
+        newMaxPrice = bound(newMaxPrice, newMinPrice.mulUp(_MIN_PRICE_RATIO), _MAX_PRICE);
+        newTargetPrice = bound(
+            newTargetPrice,
+            newMinPrice + newMinPrice.mulDown((_MIN_PRICE_RATIO - FixedPoint.ONE) / 2),
+            newMaxPrice - newMinPrice.mulDown((_MIN_PRICE_RATIO - FixedPoint.ONE) / 2)
         );
 
-        (uint256[] memory curentFirstPoolVirtualBalances, ) = ReClammPool(firstPool).getCurrentVirtualBalances();
-        (uint256[] memory curentNewPoolVirtualBalances, ) = ReClammPool(secondPool).getCurrentVirtualBalances();
+        // Assume the pool is in range, else the initialization will revert.
+        _assumePoolInRange(newMinPrice, newMaxPrice, newTargetPrice);
 
-        if (diffCoefficient > 0) {
-            assertGt(
-                curentNewPoolVirtualBalances[0],
-                curentFirstPoolVirtualBalances[0],
-                "Virtual A balance should be greater for newPool"
-            );
-            assertGt(
-                curentNewPoolVirtualBalances[1],
-                curentFirstPoolVirtualBalances[1],
-                "Virtual B balance should be greater for newPool"
-            );
-        } else {
-            assertLt(
-                curentNewPoolVirtualBalances[0],
-                curentFirstPoolVirtualBalances[0],
-                "Virtual A balance should be less for newPool"
-            );
-            assertLt(
-                curentNewPoolVirtualBalances[1],
-                curentFirstPoolVirtualBalances[1],
-                "Virtual B balance should be less for newPool"
-            );
-        }
-    }
+        setInitializationPrices(newMinPrice, newMaxPrice, newTargetPrice);
+        _createNewPool();
 
-    function testWithDifferentPriceRatio__Fuzz(uint96 endFourthRootPriceRatio) public {
-        endFourthRootPriceRatio = SafeCast.toUint96(bound(endFourthRootPriceRatio, 1.001e18, 1_000_000e18)); // Price range cannot be lower than 1.
+        (, , uint256[] memory balances, ) = vault.getPoolTokenInfo(pool);
+        (uint256[] memory virtualBalances, ) = ReClammPool(pool).getCurrentVirtualBalances();
 
-        uint96 initialFourthRootPriceRatio = fourthRootPriceRatio();
-        setFourthRootPriceRatio(endFourthRootPriceRatio);
-        (address firstPool, address secondPool) = _createNewPool();
+        uint256 currentPrice = (balances[usdcIdx] + virtualBalances[usdcIdx]).divDown(
+            balances[daiIdx] + virtualBalances[daiIdx]
+        );
 
-        (uint256[] memory curentFirstPoolVirtualBalances, ) = ReClammPool(firstPool).getCurrentVirtualBalances();
-        (uint256[] memory curentNewPoolVirtualBalances, ) = ReClammPool(secondPool).getCurrentVirtualBalances();
+        assertApproxEqRel(currentPrice, newTargetPrice, _INITIAL_PARAMS_ERROR, "Current price does not match");
 
-        if (endFourthRootPriceRatio > initialFourthRootPriceRatio) {
-            assertLt(
-                curentNewPoolVirtualBalances[0],
-                curentFirstPoolVirtualBalances[0],
-                "Virtual A balance should be less for newPool"
-            );
-            assertLt(
-                curentNewPoolVirtualBalances[1],
-                curentFirstPoolVirtualBalances[1],
-                "Virtual B balance should be less for newPool"
-            );
-        } else {
-            assertGe(
-                curentNewPoolVirtualBalances[0],
-                curentFirstPoolVirtualBalances[0],
-                "Virtual A balance should be greater for newPool"
-            );
-            assertGe(
-                curentNewPoolVirtualBalances[1],
-                curentFirstPoolVirtualBalances[1],
-                "Virtual B balance should be greater for newPool"
-            );
-        }
+        uint256 balanceDaiEdge = (virtualBalances[usdcIdx] - virtualBalances[daiIdx].mulDown(newMinPrice)).divDown(
+            newMinPrice
+        );
+        uint256 invariantDaiEdge = ReClammPool(pool).computeInvariant(
+            [balanceDaiEdge, 0].toMemoryArray(),
+            Rounding.ROUND_DOWN
+        );
+
+        uint256 balanceUsdcEdge = virtualBalances[daiIdx].mulDown(newMaxPrice) - virtualBalances[usdcIdx];
+        uint256 invariantUsdcEdge = ReClammPool(pool).computeInvariant(
+            [0, balanceUsdcEdge].toMemoryArray(),
+            Rounding.ROUND_DOWN
+        );
+
+        uint256 newInvariant = _getCurrentInvariant();
+
+        assertApproxEqRel(
+            invariantDaiEdge,
+            invariantUsdcEdge,
+            _INITIAL_PARAMS_ERROR,
+            "Invariant at the edges should be equal"
+        );
+        assertApproxEqRel(invariantDaiEdge, newInvariant, _INITIAL_PARAMS_ERROR, "Invariant should be equal");
     }
 
     function testChangingDifferentPriceRatio__Fuzz(uint96 endFourthRootPriceRatio) public {
         endFourthRootPriceRatio = SafeCast.toUint96(bound(endFourthRootPriceRatio, 1.1e18, 10e18));
-
         uint256 initialFourthRootPriceRatio = ReClammPool(pool).getCurrentFourthRootPriceRatio();
+
+        if (endFourthRootPriceRatio > initialFourthRootPriceRatio) {
+            vm.assume(endFourthRootPriceRatio - initialFourthRootPriceRatio > 10);
+        } else {
+            vm.assume(initialFourthRootPriceRatio - endFourthRootPriceRatio > 10);
+        }
 
         uint32 duration = 2 hours;
 
@@ -183,9 +165,8 @@ contract ReClammPoolVirtualBalancesTest is BaseReClammTest {
     }
 
     function testSwapExactIn__Fuzz(uint256 exactAmountIn) public {
-        exactAmountIn = bound(exactAmountIn, 1e6, _INITIAL_BALANCE_A);
+        exactAmountIn = bound(exactAmountIn, 1e6, _initialBalances[daiIdx]);
 
-        (uint256[] memory oldVirtualBalances, ) = ReClammPool(pool).getCurrentVirtualBalances();
         uint256 invariantBefore = _getCurrentInvariant();
 
         vm.prank(alice);
@@ -194,15 +175,18 @@ contract ReClammPoolVirtualBalancesTest is BaseReClammTest {
         uint256 invariantAfter = _getCurrentInvariant();
         assertLe(invariantBefore, invariantAfter, "Invariant should not decrease");
 
-        (uint256[] memory newVirtualBalances, ) = ReClammPool(pool).getCurrentVirtualBalances();
-        assertEq(newVirtualBalances[0], oldVirtualBalances[0], "Virtual A balances do not match");
-        assertEq(newVirtualBalances[1], oldVirtualBalances[1], "Virtual B balances do not match");
+        (uint256[] memory currentVirtualBalances, ) = ReClammPool(pool).getCurrentVirtualBalances();
+        assertEq(currentVirtualBalances[daiIdx], _initialVirtualBalances[daiIdx], "DAI Virtual balances do not match");
+        assertEq(
+            currentVirtualBalances[usdcIdx],
+            _initialVirtualBalances[usdcIdx],
+            "USDC Virtual balances do not match"
+        );
     }
 
     function testSwapExactOut__Fuzz(uint256 exactAmountOut) public {
-        exactAmountOut = bound(exactAmountOut, 1e6, _INITIAL_BALANCE_B - _MIN_TOKEN_BALANCE - 1);
+        exactAmountOut = bound(exactAmountOut, 1e6, _initialBalances[usdcIdx] - _MIN_TOKEN_BALANCE - 1);
 
-        uint256[] memory virtualBalances = _calculateVirtualBalances();
         uint256 invariantBefore = _getCurrentInvariant();
 
         vm.prank(alice);
@@ -212,12 +196,18 @@ contract ReClammPoolVirtualBalancesTest is BaseReClammTest {
         assertLe(invariantBefore, invariantAfter, "Invariant should not decrease");
 
         (uint256[] memory currentVirtualBalances, ) = ReClammPool(pool).getCurrentVirtualBalances();
-        assertEq(currentVirtualBalances[0], virtualBalances[0], "Virtual A balances don't equal");
-        assertEq(currentVirtualBalances[1], virtualBalances[1], "Virtual B balances don't equal");
+        assertEq(currentVirtualBalances[daiIdx], _initialVirtualBalances[daiIdx], "DAI Virtual balances do not match");
+        assertEq(
+            currentVirtualBalances[usdcIdx],
+            _initialVirtualBalances[usdcIdx],
+            "USDC Virtual balances do not match"
+        );
     }
 
-    function testAddLiquidity__Fuzz(uint256 exactBptAmountOut) public {
-        exactBptAmountOut = bound(exactBptAmountOut, 1e18, 10_000e18);
+    function testAddLiquidityProportional__Fuzz(uint256 exactBptAmountOut) public {
+        exactBptAmountOut = bound(exactBptAmountOut, 1e6, 10_000e18);
+
+        uint256 currentTotalSupply = ReClammPool(pool).totalSupply();
 
         uint256 invariantBefore = _getCurrentInvariant();
 
@@ -231,14 +221,43 @@ contract ReClammPoolVirtualBalancesTest is BaseReClammTest {
         );
 
         uint256 invariantAfter = _getCurrentInvariant();
+        (, , uint256[] memory balancesAfter, ) = vault.getPoolTokenInfo(pool);
+        (uint256[] memory virtualBalancesAfter, ) = ReClammPool(pool).getCurrentVirtualBalances();
 
         assertGt(invariantAfter, invariantBefore, "Invariant should increase");
 
-        // TODO: add check for virtual balances
+        assertApproxEqRel(
+            balancesAfter[daiIdx],
+            _initialBalances[daiIdx].mulDown(FixedPoint.ONE + exactBptAmountOut.divDown(currentTotalSupply)),
+            _INITIAL_PARAMS_ERROR,
+            "DAI balances do not match"
+        );
+        assertApproxEqRel(
+            balancesAfter[usdcIdx],
+            _initialBalances[usdcIdx].mulDown(FixedPoint.ONE + exactBptAmountOut.divDown(currentTotalSupply)),
+            _INITIAL_PARAMS_ERROR,
+            "USDC balances do not match"
+        );
+
+        assertApproxEqRel(
+            virtualBalancesAfter[daiIdx],
+            _initialVirtualBalances[daiIdx].mulDown(FixedPoint.ONE + exactBptAmountOut.divDown(currentTotalSupply)),
+            _INITIAL_PARAMS_ERROR,
+            "DAI virtual balances do not match"
+        );
+        assertApproxEqRel(
+            virtualBalancesAfter[usdcIdx],
+            _initialVirtualBalances[usdcIdx].mulDown(FixedPoint.ONE + exactBptAmountOut.divDown(currentTotalSupply)),
+            _INITIAL_PARAMS_ERROR,
+            "USDC virtual balances do not match"
+        );
     }
 
     function testRemoveLiquidity__Fuzz(uint256 exactBptAmountIn) public {
-        exactBptAmountIn = bound(exactBptAmountIn, 1e18, 10_000e18);
+        // Leave at least 10% of tokens in the pool to don't trigger the error TokenBalanceTooLow().
+        exactBptAmountIn = bound(exactBptAmountIn, 1e8, (9 * ReClammPool(pool).balanceOf(lp)) / 10);
+
+        uint256 currentTotalSupply = ReClammPool(pool).totalSupply();
 
         uint256 invariantBefore = _getCurrentInvariant();
 
@@ -252,9 +271,36 @@ contract ReClammPoolVirtualBalancesTest is BaseReClammTest {
         );
 
         uint256 invariantAfter = _getCurrentInvariant();
+        (, , uint256[] memory balancesAfter, ) = vault.getPoolTokenInfo(pool);
+        (uint256[] memory virtualBalancesAfter, ) = ReClammPool(pool).getCurrentVirtualBalances();
+
         assertLt(invariantAfter, invariantBefore, "Invariant should decrease");
 
-        // TODO: add check for virtual balances
+        assertApproxEqRel(
+            balancesAfter[daiIdx],
+            _initialBalances[daiIdx].mulDown(FixedPoint.ONE - exactBptAmountIn.divDown(currentTotalSupply)),
+            _INITIAL_PARAMS_ERROR,
+            "DAI balances do not match"
+        );
+        assertApproxEqRel(
+            balancesAfter[usdcIdx],
+            _initialBalances[usdcIdx].mulDown(FixedPoint.ONE - exactBptAmountIn.divDown(currentTotalSupply)),
+            _INITIAL_PARAMS_ERROR,
+            "USDC balances do not match"
+        );
+
+        assertApproxEqRel(
+            virtualBalancesAfter[daiIdx],
+            _initialVirtualBalances[daiIdx].mulDown(FixedPoint.ONE - exactBptAmountIn.divDown(currentTotalSupply)),
+            _INITIAL_PARAMS_ERROR,
+            "DAI virtual balances do not match"
+        );
+        assertApproxEqRel(
+            virtualBalancesAfter[usdcIdx],
+            _initialVirtualBalances[usdcIdx].mulDown(FixedPoint.ONE - exactBptAmountIn.divDown(currentTotalSupply)),
+            _INITIAL_PARAMS_ERROR,
+            "USDC virtual balances do not match"
+        );
     }
 
     function _getCurrentInvariant() internal view returns (uint256) {
@@ -262,19 +308,17 @@ contract ReClammPoolVirtualBalancesTest is BaseReClammTest {
         return ReClammPool(pool).computeInvariant(balances, Rounding.ROUND_DOWN);
     }
 
-    function _calculateVirtualBalances() internal view returns (uint256[] memory virtualBalances) {
-        virtualBalances = new uint256[](2);
-
-        uint256 fourthRootPriceRatioMinusOne = fourthRootPriceRatio() - FixedPoint.ONE;
-        virtualBalances[0] = _INITIAL_BALANCE_A.divDown(fourthRootPriceRatioMinusOne);
-        virtualBalances[1] = _INITIAL_BALANCE_B.divDown(fourthRootPriceRatioMinusOne);
-    }
-
     function _createNewPool() internal returns (address initalPool, address newPool) {
-        initalPool = pool;
         (pool, poolArguments) = createPool();
         approveForPool(IERC20(pool));
         initPool();
-        newPool = pool;
+    }
+
+    function _assumePoolInRange(uint256 newMinPrice, uint256 newMaxPrice, uint256 newTargetPrice) internal view {
+        (uint256[] memory balances, uint256[] memory virtualBalances, ) = ReClammMath
+            .getTheoreticalPriceRatioAndBalances(newMinPrice, newMaxPrice, newTargetPrice);
+
+        uint256 centeredness = ReClammMath.calculateCenteredness(balances, virtualBalances);
+        vm.assume(centeredness > _DEFAULT_CENTEREDNESS_MARGIN);
     }
 }

--- a/test/foundry/ReClammRounding.t.sol
+++ b/test/foundry/ReClammRounding.t.sol
@@ -15,13 +15,15 @@ import { BaseReClammTest } from "./utils/BaseReClammTest.sol";
 
 contract ReClammRoundingTest is BaseReClammTest {
     using SafeCast for *;
+    using FixedPoint for uint256;
 
     uint256 internal constant _DELTA = 1e3;
 
     uint256 internal constant _MIN_SWAP_AMOUNT = 1e12;
 
-    uint256 internal constant _MIN_FOURTH_ROOT_PRICE_RATIO = 1.000001e18; // 1.000001
-    uint256 internal constant _MAX_FOURTH_ROOT_PRICE_RATIO = 10e18;
+    uint256 internal constant _MIN_PRICE = 1e14; // 0.0001
+    uint256 internal constant _MAX_PRICE = 1e24; // 1_000_000
+    uint256 internal constant _MIN_PRICE_RATIO = 1.1e18;
     uint256 internal constant _MAX_TIME_CONSTANT = FixedPoint.ONE - 1;
 
     uint256 internal constant _MIN_SWAP_FEE = 0;
@@ -35,16 +37,20 @@ contract ReClammRoundingTest is BaseReClammTest {
         mathMock = new ReClammMathMock();
     }
 
-    function testPureComputeInvariant__Fuzz(uint256[2] memory balancesRaw, uint256 fourthRootPriceRatio) public view {
-        uint256[] memory balances = new uint256[](balancesRaw.length);
-        for (uint256 i = 0; i < balances.length; ++i) {
-            balances[i] = bound(balancesRaw[i], _MIN_TOKEN_BALANCE, _MAX_TOKEN_BALANCE);
-        }
+    function testPureComputeInvariant__Fuzz(uint256 minPrice, uint256 maxPrice, uint256 targetPrice) public view {
+        minPrice = bound(minPrice, _MIN_PRICE, _MAX_PRICE.divDown(_MIN_PRICE_RATIO));
+        maxPrice = bound(maxPrice, minPrice.mulUp(_MIN_PRICE_RATIO), _MAX_PRICE);
+        targetPrice = bound(
+            targetPrice,
+            minPrice + minPrice.mulDown((_MIN_PRICE_RATIO - FixedPoint.ONE) / 2),
+            maxPrice - minPrice.mulDown((_MIN_PRICE_RATIO - FixedPoint.ONE) / 2)
+        );
 
-        fourthRootPriceRatio = bound(fourthRootPriceRatio, _MIN_FOURTH_ROOT_PRICE_RATIO, _MAX_FOURTH_ROOT_PRICE_RATIO)
-            .toUint96();
-
-        uint256[] memory virtualBalances = mathMock.initializeVirtualBalances(balances, fourthRootPriceRatio);
+        (uint256[] memory balances, uint256[] memory virtualBalances, ) = mathMock.getTheoreticalPriceRatioAndBalances(
+            minPrice,
+            maxPrice,
+            targetPrice
+        );
 
         uint256 invariantRoundedUp = mathMock.computeInvariant(balances, virtualBalances, Rounding.ROUND_UP);
         uint256 invariantRoundedDown = mathMock.computeInvariant(balances, virtualBalances, Rounding.ROUND_DOWN);
@@ -57,21 +63,27 @@ contract ReClammRoundingTest is BaseReClammTest {
     }
 
     function testCalculateOutGivenIn__Fuzz(
-        uint256[2] calldata balancesRaw,
-        uint96 fourthRootPriceRatio,
+        uint256 minPrice,
+        uint256 maxPrice,
+        uint256 targetPrice,
         bool isTokenAIn,
         uint256 amountGivenScaled18
     ) external {
+        minPrice = bound(minPrice, _MIN_PRICE, _MAX_PRICE.divDown(_MIN_PRICE_RATIO));
+        maxPrice = bound(maxPrice, minPrice.mulUp(_MIN_PRICE_RATIO), _MAX_PRICE);
+        targetPrice = bound(
+            targetPrice,
+            minPrice + minPrice.mulDown((_MIN_PRICE_RATIO - FixedPoint.ONE) / 2),
+            maxPrice - minPrice.mulDown((_MIN_PRICE_RATIO - FixedPoint.ONE) / 2)
+        );
+
+        (uint256[] memory balances, uint256[] memory virtualBalances, uint256 fourthRootPriceRatio) = mathMock
+            .getTheoreticalPriceRatioAndBalances(minPrice, maxPrice, targetPrice);
+
         (uint256 tokenInIndex, uint256 tokenOutIndex) = isTokenAIn ? (0, 1) : (1, 0);
 
-        uint256[] memory balances = new uint256[](balancesRaw.length);
-        for (uint256 i = 0; i < balances.length; ++i) {
-            balances[i] = bound(balancesRaw[i], _MIN_TOKEN_BALANCE + 1, _MAX_TOKEN_BALANCE);
-        }
-        fourthRootPriceRatio = bound(fourthRootPriceRatio, _MIN_FOURTH_ROOT_PRICE_RATIO, _MAX_FOURTH_ROOT_PRICE_RATIO)
-            .toUint96();
-
-        uint256[] memory virtualBalances = mathMock.initializeVirtualBalances(balances, fourthRootPriceRatio);
+        vm.assume(balances[tokenOutIndex] > _MIN_TOKEN_BALANCE);
+        vm.assume(balances[tokenInIndex] > _MIN_TOKEN_BALANCE);
 
         // Calculate maxAmountIn to make sure the transaction won't revert.
         uint256 maxAmountIn = mathMock.calculateInGivenOut(
@@ -86,8 +98,8 @@ contract ReClammRoundingTest is BaseReClammTest {
         amountGivenScaled18 = bound(amountGivenScaled18, _MIN_SWAP_AMOUNT, maxAmountIn);
         mathMock.setPriceRatioState(
             PriceRatioState({
-                startFourthRootPriceRatio: fourthRootPriceRatio,
-                endFourthRootPriceRatio: fourthRootPriceRatio,
+                startFourthRootPriceRatio: fourthRootPriceRatio.toUint96(),
+                endFourthRootPriceRatio: fourthRootPriceRatio.toUint96(),
                 priceRatioUpdateStartTime: 0,
                 priceRatioUpdateEndTime: 0
             })
@@ -123,19 +135,27 @@ contract ReClammRoundingTest is BaseReClammTest {
     }
 
     function testCalculateInGivenOut__Fuzz(
-        uint256[2] calldata balancesRaw,
-        uint96 fourthRootPriceRatio,
+        uint256 minPrice,
+        uint256 maxPrice,
+        uint256 targetPrice,
         bool isTokenAIn,
         uint256 amountGivenScaled18
     ) external {
-        uint256[] memory balances = new uint256[](balancesRaw.length);
+        minPrice = bound(minPrice, _MIN_PRICE, _MAX_PRICE.divDown(_MIN_PRICE_RATIO));
+        maxPrice = bound(maxPrice, minPrice.mulUp(_MIN_PRICE_RATIO), _MAX_PRICE);
+        targetPrice = bound(
+            targetPrice,
+            minPrice + minPrice.mulDown((_MIN_PRICE_RATIO - FixedPoint.ONE) / 2),
+            maxPrice - minPrice.mulDown((_MIN_PRICE_RATIO - FixedPoint.ONE) / 2)
+        );
+
+        (uint256[] memory balances, uint256[] memory virtualBalances, uint256 fourthRootPriceRatio) = mathMock
+            .getTheoreticalPriceRatioAndBalances(minPrice, maxPrice, targetPrice);
+
         (uint256 tokenInIndex, uint256 tokenOutIndex) = isTokenAIn ? (0, 1) : (1, 0);
 
-        for (uint256 i = 0; i < balances.length; ++i) {
-            balances[i] = bound(balancesRaw[i], _MIN_TOKEN_BALANCE + 1, _MAX_TOKEN_BALANCE);
-        }
-        fourthRootPriceRatio = bound(fourthRootPriceRatio, _MIN_FOURTH_ROOT_PRICE_RATIO, _MAX_FOURTH_ROOT_PRICE_RATIO)
-            .toUint96();
+        vm.assume(balances[tokenOutIndex] > _MIN_TOKEN_BALANCE);
+        vm.assume(balances[tokenInIndex] > _MIN_TOKEN_BALANCE);
 
         vm.assume(_MIN_SWAP_AMOUNT <= balances[tokenOutIndex] - _MIN_TOKEN_BALANCE - 1);
         amountGivenScaled18 = bound(
@@ -144,12 +164,10 @@ contract ReClammRoundingTest is BaseReClammTest {
             balances[tokenOutIndex] - _MIN_TOKEN_BALANCE - 1
         );
 
-        uint256[] memory virtualBalances = mathMock.initializeVirtualBalances(balances, fourthRootPriceRatio);
-
         mathMock.setPriceRatioState(
             PriceRatioState({
-                startFourthRootPriceRatio: fourthRootPriceRatio,
-                endFourthRootPriceRatio: fourthRootPriceRatio,
+                startFourthRootPriceRatio: fourthRootPriceRatio.toUint96(),
+                endFourthRootPriceRatio: fourthRootPriceRatio.toUint96(),
                 priceRatioUpdateStartTime: 0,
                 priceRatioUpdateEndTime: 0
             })

--- a/test/foundry/ReClammRounding.t.sol
+++ b/test/foundry/ReClammRounding.t.sol
@@ -21,9 +21,6 @@ contract ReClammRoundingTest is BaseReClammTest {
 
     uint256 internal constant _MIN_SWAP_AMOUNT = 1e12;
 
-    uint256 internal constant _MIN_PRICE = 1e14; // 0.0001
-    uint256 internal constant _MAX_PRICE = 1e24; // 1_000_000
-    uint256 internal constant _MIN_PRICE_RATIO = 1.1e18;
     uint256 internal constant _MAX_TIME_CONSTANT = FixedPoint.ONE - 1;
 
     uint256 internal constant _MIN_SWAP_FEE = 0;

--- a/test/foundry/utils/BaseReClammTest.sol
+++ b/test/foundry/utils/BaseReClammTest.sol
@@ -44,8 +44,6 @@ contract BaseReClammTest is ReClammPoolContractsDeployer, BaseVaultTest {
     uint256 internal constant _MAX_PRICE = 1e24; // 1_000_000
     uint256 internal constant _MIN_PRICE_RATIO = 1.1e18;
 
-    uint256 internal defaultFourthRootPriceRatio;
-
     // 0.0001 tokens.
     uint256 internal constant _MIN_TOKEN_BALANCE = 1e14;
     // 1 billion tokens.

--- a/test/foundry/utils/BaseReClammTest.sol
+++ b/test/foundry/utils/BaseReClammTest.sol
@@ -146,6 +146,11 @@ contract BaseReClammTest is ReClammPoolContractsDeployer, BaseVaultTest {
             vm.assume(dai.balanceOf(lp) > _initialBalances[daiIdx]);
             _initialBalances[usdcIdx] = poolInitAmount.mulDown(proportion);
             vm.assume(usdc.balanceOf(lp) > _initialBalances[usdcIdx]);
+        } else {
+            _initialBalances[usdcIdx] = poolInitAmount;
+            vm.assume(usdc.balanceOf(lp) > _initialBalances[usdcIdx]);
+            _initialBalances[daiIdx] = poolInitAmount.mulDown(proportion);
+            vm.assume(dai.balanceOf(lp) > _initialBalances[daiIdx]);
         }
 
         vm.startPrank(lp);

--- a/test/foundry/utils/BaseReClammTest.sol
+++ b/test/foundry/utils/BaseReClammTest.sol
@@ -39,6 +39,11 @@ contract BaseReClammTest is ReClammPoolContractsDeployer, BaseVaultTest {
     uint256 internal constant _DEFAULT_TARGET_PRICE = 2500e18;
     uint256 internal constant _DEFAULT_PRICE_SHIFT_DAILY_RATE = 100e16; // 100%
     uint64 internal constant _DEFAULT_CENTEREDNESS_MARGIN = 20e16; // 20%
+
+    uint256 internal constant _MIN_PRICE = 1e14; // 0.0001
+    uint256 internal constant _MAX_PRICE = 1e24; // 1_000_000
+    uint256 internal constant _MIN_PRICE_RATIO = 1.1e18;
+
     uint256 internal defaultFourthRootPriceRatio;
 
     // 0.0001 tokens.
@@ -46,9 +51,14 @@ contract BaseReClammTest is ReClammPoolContractsDeployer, BaseVaultTest {
     // 1 billion tokens.
     uint256 internal constant _MAX_TOKEN_BALANCE = 1e9 * 1e18;
 
-    uint96 private _fourthRootPriceRatio;
     uint256 private _priceShiftDailyRate = _DEFAULT_PRICE_SHIFT_DAILY_RATE;
-    uint256[] private _initialBalances = new uint256[](2);
+
+    uint256[] internal _initialBalances;
+    uint256[] internal _initialVirtualBalances;
+    uint256 internal _initialFourthRootPriceRatio;
+    uint256 private _initialMinPrice = _DEFAULT_MIN_PRICE;
+    uint256 private _initialMaxPrice = _DEFAULT_MAX_PRICE;
+    uint256 private _initialTargetPrice = _DEFAULT_TARGET_PRICE;
 
     uint256 internal saltNumber = 0;
 
@@ -60,35 +70,19 @@ contract BaseReClammTest is ReClammPoolContractsDeployer, BaseVaultTest {
     function setUp() public virtual override {
         super.setUp();
 
-        defaultFourthRootPriceRatio = Math.sqrt(
-            Math.sqrt((_DEFAULT_MAX_PRICE * FixedPoint.ONE).divDown(_DEFAULT_MIN_PRICE)) * FixedPoint.ONE
-        );
+        (, , _initialBalances, ) = vault.getPoolTokenInfo(pool);
+        (_initialVirtualBalances, ) = ReClammPool(pool).getCurrentVirtualBalances();
+        _initialFourthRootPriceRatio = ReClammPool(pool).getCurrentFourthRootPriceRatio();
     }
 
-    function setPriceRatio(uint256 priceRatio) internal {
-        priceRatio = Math.sqrt(priceRatio * FixedPoint.ONE);
-        _fourthRootPriceRatio = SafeCast.toUint96(Math.sqrt(priceRatio * FixedPoint.ONE));
-    }
-
-    function setFourthRootPriceRatio(uint96 endFourthRootPriceRatio) internal {
-        _fourthRootPriceRatio = endFourthRootPriceRatio;
-    }
-
-    function fourthRootPriceRatio() internal view returns (uint96) {
-        return _fourthRootPriceRatio;
+    function setInitializationPrices(uint256 newMinPrice, uint256 newMaxPrice, uint256 newTargetPrice) internal {
+        _initialMinPrice = newMinPrice;
+        _initialMaxPrice = newMaxPrice;
+        _initialTargetPrice = newTargetPrice;
     }
 
     function setPriceShiftDailyRate(uint256 priceShiftDailyRate) internal {
         _priceShiftDailyRate = priceShiftDailyRate;
-    }
-
-    function setInitialBalances(uint256 aBalance, uint256 bBalance) internal {
-        _initialBalances[0] = aBalance;
-        _initialBalances[1] = bBalance;
-    }
-
-    function initialBalances() internal view returns (uint256[] memory) {
-        return _initialBalances;
     }
 
     function createPoolFactory() internal override returns (address) {
@@ -117,9 +111,9 @@ contract BaseReClammTest is ReClammPoolContractsDeployer, BaseVaultTest {
             vault.buildTokenConfig(sortedTokens),
             roleAccounts,
             _DEFAULT_SWAP_FEE,
-            _DEFAULT_MIN_PRICE,
-            _DEFAULT_MAX_PRICE,
-            _DEFAULT_TARGET_PRICE,
+            _initialMinPrice,
+            _initialMaxPrice,
+            _initialTargetPrice,
             _DEFAULT_PRICE_SHIFT_DAILY_RATE,
             _DEFAULT_CENTEREDNESS_MARGIN,
             bytes32(saltNumber++)
@@ -132,9 +126,9 @@ contract BaseReClammTest is ReClammPoolContractsDeployer, BaseVaultTest {
                 name: name,
                 symbol: symbol,
                 version: _POOL_VERSION,
-                initialMinPrice: _DEFAULT_MIN_PRICE,
-                initialMaxPrice: _DEFAULT_MAX_PRICE,
-                initialTargetPrice: _DEFAULT_TARGET_PRICE,
+                initialMinPrice: _initialMinPrice,
+                initialMaxPrice: _initialMaxPrice,
+                initialTargetPrice: _initialTargetPrice,
                 priceShiftDailyRate: _DEFAULT_PRICE_SHIFT_DAILY_RATE,
                 centerednessMargin: _DEFAULT_CENTEREDNESS_MARGIN
             }),
@@ -147,9 +141,13 @@ contract BaseReClammTest is ReClammPoolContractsDeployer, BaseVaultTest {
 
         uint256 proportion = ReClammPool(pool).getInitializationProportion();
 
+        _initialBalances = new uint256[](2);
+
         if (daiIdx < usdcIdx) {
             _initialBalances[daiIdx] = poolInitAmount;
+            vm.assume(dai.balanceOf(lp) > _initialBalances[daiIdx]);
             _initialBalances[usdcIdx] = poolInitAmount.mulDown(proportion);
+            vm.assume(usdc.balanceOf(lp) > _initialBalances[usdcIdx]);
         }
 
         vm.startPrank(lp);

--- a/test/foundry/utils/ReClammPoolContractsDeployer.sol
+++ b/test/foundry/utils/ReClammPoolContractsDeployer.sol
@@ -27,9 +27,11 @@ contract ReClammPoolContractsDeployer is BaseContractsDeployer {
     struct DefaultDeployParams {
         string name;
         string symbol;
+        uint256 defaultMinPrice;
+        uint256 defaultMaxPrice;
+        uint256 defaultTargetPrice;
         uint256 defaultPriceShiftDailyRate;
         uint256 defaultCenterednessMargin;
-        uint96 defaultFourthRootPriceRatio;
         string poolVersion;
         string factoryVersion;
     }
@@ -43,9 +45,11 @@ contract ReClammPoolContractsDeployer is BaseContractsDeployer {
         defaultParams = DefaultDeployParams({
             name: "ReClamm Pool",
             symbol: "RECLAMMPOOL",
+            defaultMinPrice: 1000e18,
+            defaultMaxPrice: 4000e18,
+            defaultTargetPrice: 2500e18,
             defaultPriceShiftDailyRate: 100e16, // 100%
             defaultCenterednessMargin: 10e16, // 10%
-            defaultFourthRootPriceRatio: 1.41421356e18, // Price Range of 4 (fourth square root is 1.41)
             poolVersion: "ReClamm Pool v1",
             factoryVersion: "ReClamm Pool Factory v1"
         });
@@ -76,8 +80,10 @@ contract ReClammPoolContractsDeployer is BaseContractsDeployer {
             vault.buildTokenConfig(_tokens),
             roleAccounts,
             0,
+            defaultParams.defaultMinPrice,
+            defaultParams.defaultMaxPrice,
+            defaultParams.defaultTargetPrice,
             defaultParams.defaultPriceShiftDailyRate,
-            defaultParams.defaultFourthRootPriceRatio,
             SafeCast.toUint64(defaultParams.defaultCenterednessMargin),
             bytes32(_saltIndex++)
         );
@@ -89,8 +95,10 @@ contract ReClammPoolContractsDeployer is BaseContractsDeployer {
                 name: defaultParams.name,
                 symbol: defaultParams.symbol,
                 version: defaultParams.poolVersion,
+                initialMinPrice: defaultParams.defaultMinPrice,
+                initialMaxPrice: defaultParams.defaultMaxPrice,
+                initialTargetPrice: defaultParams.defaultTargetPrice,
                 priceShiftDailyRate: defaultParams.defaultPriceShiftDailyRate,
-                fourthRootPriceRatio: defaultParams.defaultFourthRootPriceRatio,
                 centerednessMargin: SafeCast.toUint64(defaultParams.defaultCenterednessMargin)
             }),
             vault

--- a/test/foundry/utils/ReClammPoolContractsDeployer.sol
+++ b/test/foundry/utils/ReClammPoolContractsDeployer.sol
@@ -42,12 +42,14 @@ contract ReClammPoolContractsDeployer is BaseContractsDeployer {
     uint256 private _saltIndex = 0;
 
     constructor() {
+        // This is used only by E2E tests. They require a pool with the same initial balance in both tokens, so this
+        // setup covers it.
         defaultParams = DefaultDeployParams({
             name: "ReClamm Pool",
             symbol: "RECLAMMPOOL",
-            defaultMinPrice: 1000e18,
-            defaultMaxPrice: 4000e18,
-            defaultTargetPrice: 2500e18,
+            defaultMinPrice: 0.5e18,
+            defaultMaxPrice: 2e18,
+            defaultTargetPrice: 1e18,
             defaultPriceShiftDailyRate: 100e16, // 100%
             defaultCenterednessMargin: 10e16, // 10%
             poolVersion: "ReClamm Pool v1",


### PR DESCRIPTION
# Description

This PR changes the way that we create and initialize the ReClamm pool, improving the UX. Now, instead of using the price ratio, we use a min, max and target prices. The step by step math of this changed is explained here: https://www.notion.so/Readjusting-CL-AMM-Implementation-1a4e395e22818028ac84c47983c63bf6?pvs=4#1a4e395e22818074a2a1f1b38907e8ec

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #62 