### PR TITLE
Compute virtual balances in Add/Remove Liquidity hook consistently with swaps

### DIFF
--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -317,15 +317,14 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
         // after adding liquidity. This is needed to keep the pool centeredness and price ratio constant.
 
         uint256 poolTotalSupply = _vault.totalSupply(pool);
-        // Rounding proportion up, which will round the virtual balances up.
-        uint256 proportion = minBptAmountOut.divUp(poolTotalSupply);
+        // Rounding proportion down, which will round the virtual balances down.
+        uint256 proportion = minBptAmountOut.divDown(poolTotalSupply);
 
         (uint256[] memory currentVirtualBalances, ) = _computeCurrentVirtualBalances(balancesScaled18);
-        // When adding/removing liquidity, round up the virtual balances. This will result in a higher invariant,
-        // which favors the vault in swap operations. The virtual balances are not used to calculate a proportional
-        // add/remove result.
-        currentVirtualBalances[a] = currentVirtualBalances[a].mulUp(FixedPoint.ONE + proportion);
-        currentVirtualBalances[b] = currentVirtualBalances[b].mulUp(FixedPoint.ONE + proportion);
+        // When adding/removing liquidity, round down the virtual balances. This favors the vault in swap operations.
+        // The virtual balances are not used to calculate a proportional add/remove result.
+        currentVirtualBalances[a] = currentVirtualBalances[a].mulDown(FixedPoint.ONE + proportion);
+        currentVirtualBalances[b] = currentVirtualBalances[b].mulDown(FixedPoint.ONE + proportion);
         _setLastVirtualBalances(currentVirtualBalances);
         _updateTimestamp();
 
@@ -346,15 +345,14 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
         // after removing liquidity. This is needed to keep the pool centeredness and price ratio constant.
 
         uint256 poolTotalSupply = _vault.totalSupply(pool);
-        // Rounding proportion down, which will round the virtual balances up.
-        uint256 proportion = maxBptAmountIn.divDown(poolTotalSupply);
+        // Rounding proportion up, which will round the virtual balances down.
+        uint256 proportion = maxBptAmountIn.divUp(poolTotalSupply);
 
         (uint256[] memory currentVirtualBalances, ) = _computeCurrentVirtualBalances(balancesScaled18);
-        // When adding/removing liquidity, round up the virtual balances. This will result in a higher invariant,
-        // which favors the vault in swap operations. The virtual balances are not used in the proportional
-        // add/remove calculations.
-        currentVirtualBalances[a] = currentVirtualBalances[a].mulUp(FixedPoint.ONE - proportion);
-        currentVirtualBalances[b] = currentVirtualBalances[b].mulUp(FixedPoint.ONE - proportion);
+        // When adding/removing liquidity, round down the virtual balances. This favors the vault in swap operations.
+        // The virtual balances are not used to calculate a proportional add/remove result.
+        currentVirtualBalances[a] = currentVirtualBalances[a].mulDown(FixedPoint.ONE - proportion);
+        currentVirtualBalances[b] = currentVirtualBalances[b].mulDown(FixedPoint.ONE - proportion);
         _setLastVirtualBalances(currentVirtualBalances);
         _updateTimestamp();
 

--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -322,7 +322,7 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
 
         (uint256[] memory currentVirtualBalances, ) = _computeCurrentVirtualBalances(balancesScaled18);
         // When adding/removing liquidity, round down the virtual balances. This favors the vault in swap operations.
-        // The virtual balances are not used to calculate a proportional add/remove result.
+        // The virtual balances are not used in proportional add/remove calculations.
         currentVirtualBalances[a] = currentVirtualBalances[a].mulDown(FixedPoint.ONE + proportion);
         currentVirtualBalances[b] = currentVirtualBalances[b].mulDown(FixedPoint.ONE + proportion);
         _setLastVirtualBalances(currentVirtualBalances);
@@ -350,7 +350,7 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
 
         (uint256[] memory currentVirtualBalances, ) = _computeCurrentVirtualBalances(balancesScaled18);
         // When adding/removing liquidity, round down the virtual balances. This favors the vault in swap operations.
-        // The virtual balances are not used to calculate a proportional add/remove result.
+        // The virtual balances are not used in proportional add/remove calculations.
         currentVirtualBalances[a] = currentVirtualBalances[a].mulDown(FixedPoint.ONE - proportion);
         currentVirtualBalances[b] = currentVirtualBalances[b].mulDown(FixedPoint.ONE - proportion);
         _setLastVirtualBalances(currentVirtualBalances);

--- a/test/foundry/ReClammLiquidity.t.sol
+++ b/test/foundry/ReClammLiquidity.t.sol
@@ -49,15 +49,15 @@ contract ReClammLiquidityTest is BaseReClammTest {
         (, , uint256[] memory balancesAfter, ) = vault.getPoolTokenInfo(pool);
 
         // Check if virtual balances were correctly updated.
-        uint256 proportion = exactBptAmountOut.divUp(totalSupply);
+        uint256 proportion = exactBptAmountOut.divDown(totalSupply);
         assertEq(
             virtualBalancesAfter[daiIdx],
-            virtualBalancesBefore[daiIdx].mulUp(FixedPoint.ONE + proportion),
+            virtualBalancesBefore[daiIdx].mulDown(FixedPoint.ONE + proportion),
             "DAI virtual balances do not match"
         );
         assertEq(
             virtualBalancesAfter[usdcIdx],
-            virtualBalancesBefore[usdcIdx].mulUp(FixedPoint.ONE + proportion),
+            virtualBalancesBefore[usdcIdx].mulDown(FixedPoint.ONE + proportion),
             "USDC virtual balances do not match"
         );
 
@@ -109,15 +109,15 @@ contract ReClammLiquidityTest is BaseReClammTest {
         (, , uint256[] memory balancesAfter, ) = vault.getPoolTokenInfo(pool);
 
         // Check if virtual balances were correctly updated.
-        uint256 proportion = exactBptAmountOut.divUp(totalSupply);
+        uint256 proportion = exactBptAmountOut.divDown(totalSupply);
         assertEq(
             virtualBalancesAfter[daiIdx],
-            virtualBalancesBefore[daiIdx].mulUp(FixedPoint.ONE + proportion),
+            virtualBalancesBefore[daiIdx].mulDown(FixedPoint.ONE + proportion),
             "DAI virtual balances do not match"
         );
         assertEq(
             virtualBalancesAfter[usdcIdx],
-            virtualBalancesBefore[usdcIdx].mulUp(FixedPoint.ONE + proportion),
+            virtualBalancesBefore[usdcIdx].mulDown(FixedPoint.ONE + proportion),
             "USDC virtual balances do not match"
         );
 
@@ -222,15 +222,15 @@ contract ReClammLiquidityTest is BaseReClammTest {
         (, , uint256[] memory balancesAfter, ) = vault.getPoolTokenInfo(pool);
 
         // Check if virtual balances were correctly updated.
-        uint256 proportion = exactBptAmountIn.divDown(totalSupply);
+        uint256 proportion = exactBptAmountIn.divUp(totalSupply);
         assertEq(
             virtualBalancesAfter[daiIdx],
-            virtualBalancesBefore[daiIdx].mulUp(FixedPoint.ONE - proportion),
+            virtualBalancesBefore[daiIdx].mulDown(FixedPoint.ONE - proportion),
             "DAI virtual balances do not match"
         );
         assertEq(
             virtualBalancesAfter[usdcIdx],
-            virtualBalancesBefore[usdcIdx].mulUp(FixedPoint.ONE - proportion),
+            virtualBalancesBefore[usdcIdx].mulDown(FixedPoint.ONE - proportion),
             "USDC virtual balances do not match"
         );
 
@@ -282,15 +282,15 @@ contract ReClammLiquidityTest is BaseReClammTest {
         (, , uint256[] memory balancesAfter, ) = vault.getPoolTokenInfo(pool);
 
         // Check if virtual balances were correctly updated.
-        uint256 proportion = exactBptAmountIn.divDown(totalSupply);
+        uint256 proportion = exactBptAmountIn.divUp(totalSupply);
         assertEq(
             virtualBalancesAfter[daiIdx],
-            virtualBalancesBefore[daiIdx].mulUp(FixedPoint.ONE - proportion),
+            virtualBalancesBefore[daiIdx].mulDown(FixedPoint.ONE - proportion),
             "DAI virtual balances do not match"
         );
         assertEq(
             virtualBalancesAfter[usdcIdx],
-            virtualBalancesBefore[usdcIdx].mulUp(FixedPoint.ONE - proportion),
+            virtualBalancesBefore[usdcIdx].mulDown(FixedPoint.ONE - proportion),
             "USDC virtual balances do not match"
         );
 


### PR DESCRIPTION
# Description

Swaps round virtual balances down, because it favors the vault.
In the current implementation of Add/Remove liquidity hooks, we were rounding Virtual Balances up because it rounded invariant up, however this is not more important than the result of the swap.

This PR makes the add/remove liquidity computation of the new virtual balances consistent with the swap, rounding virtual balances down.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge
