### PR TITLE
Change max centeredness margin

### DIFF
--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -39,7 +39,7 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
 
     // The centeredness margin defines the minimum pool centeredness to consider the pool within the target range.
     uint256 internal constant _MIN_CENTEREDNESS_MARGIN = 0;
-    uint256 internal constant _MAX_CENTEREDNESS_MARGIN = FixedPoint.ONE;
+    uint256 internal constant _MAX_CENTEREDNESS_MARGIN = 50e16; // 50%
 
     // A pool is "centered" when it holds equal (non-zero) value in both real token balances. In this state, the ratio
     // of the real balances equals the ratio of the virtual balances, and the value of the centeredness measure is

--- a/test/foundry/ReClammPool.t.sol
+++ b/test/foundry/ReClammPool.t.sol
@@ -280,7 +280,7 @@ contract ReClammPoolTest is BaseReClammTest {
         assertEq(data.decimalScalingFactors[usdcIdx], 1, "Invalid USDC decimal scaling factor");
 
         assertEq(data.minCenterednessMargin, 0, "Invalid min centeredness margin");
-        assertEq(data.maxCenterednessMargin, FixedPoint.ONE, "Invalid max centeredness margin");
+        assertEq(data.maxCenterednessMargin, 50e16, "Invalid max centeredness margin");
 
         // Ensure that centeredness margin parameters fit in uint64
         assertEq(data.minCenterednessMargin, uint64(data.minCenterednessMargin), "Min centeredness margin not uint64");


### PR DESCRIPTION
# Description

We'd discussed this off-line, whether and how to restrict the current full range of centeredness margin. A value of zero basically uses the entire range, effectively turning off the ReClamm features and falling back to what is essentially a Gyro pool. While 0 somewhat defeats the purpose of the pool, there's really no reason to exclude it (and it could be useful to have this option if it's misbehaving somehow). Values greater than 50% really don't make sense, and a value of 50% would basically require perfect balance.

So this limits the maximum to 50%, and leaves the minimum at 0%.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
