### PR TITLE
Add stop functionality to price ratio update

### DIFF
--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -587,7 +587,29 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
             revert PriceRatioUpdateDurationTooShort();
         }
 
-        _setPriceRatioState(endFourthRootPriceRatio, actualPriceRatioUpdateStartTime, priceRatioUpdateEndTime);
+        _updateVirtualBalances();
+        uint256 fourthRootPriceRatioDelta = _setPriceRatioState(
+            endFourthRootPriceRatio,
+            actualPriceRatioUpdateStartTime,
+            priceRatioUpdateEndTime
+        );
+
+        if (fourthRootPriceRatioDelta < _MIN_FOURTH_ROOT_PRICE_RATIO_DELTA) {
+            revert FourthRootPriceRatioDeltaBelowMin(fourthRootPriceRatioDelta);
+        }
+    }
+
+    /// @inheritdoc IReClammPool
+    function stopPriceRatioUpdate() external onlyWhenInitialized onlySwapFeeManagerOrGovernance(address(this)) {
+        _updateVirtualBalances();
+
+        PriceRatioState memory priceRatioState = _priceRatioState;
+        if (priceRatioState.priceRatioUpdateEndTime < block.timestamp) {
+            revert PriceRatioNotUpdating();
+        }
+
+        uint256 currentFourthRootPriceRatio = _computeCurrentFourthRootPriceRatio(priceRatioState);
+        _setPriceRatioState(currentFourthRootPriceRatio, block.timestamp, block.timestamp);
     }
 
     /// @inheritdoc IReClammPool
@@ -648,7 +670,7 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
         uint256 endFourthRootPriceRatio,
         uint256 priceRatioUpdateStartTime,
         uint256 priceRatioUpdateEndTime
-    ) internal {
+    ) internal returns (uint256 fourthRootPriceRatioDelta) {
         if (priceRatioUpdateStartTime > priceRatioUpdateEndTime || priceRatioUpdateStartTime < block.timestamp) {
             revert InvalidStartTime();
         }
@@ -657,13 +679,9 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
 
         uint256 startFourthRootPriceRatio = _computeCurrentFourthRootPriceRatio(priceRatioState);
 
-        uint256 fourthRootPriceRatioDelta = SignedMath.abs(
+        fourthRootPriceRatioDelta = SignedMath.abs(
             startFourthRootPriceRatio.toInt256() - endFourthRootPriceRatio.toInt256()
         );
-
-        if (fourthRootPriceRatioDelta < _MIN_FOURTH_ROOT_PRICE_RATIO_DELTA) {
-            revert FourthRootPriceRatioDeltaBelowMin(fourthRootPriceRatioDelta);
-        }
 
         priceRatioState.startFourthRootPriceRatio = startFourthRootPriceRatio.toUint96();
         priceRatioState.endFourthRootPriceRatio = endFourthRootPriceRatio.toUint96();
@@ -696,14 +714,7 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
         uint256 dailyPriceShiftExponent
     ) internal returns (uint256) {
         // Update virtual balances with current daily price shift exponent.
-        (, , , uint256[] memory balancesScaled18) = _vault.getPoolTokenInfo(address(this));
-        (uint256 currentVirtualBalanceA, uint256 currentVirtualBalanceB, bool changed) = _computeCurrentVirtualBalances(
-            balancesScaled18
-        );
-        if (changed) {
-            _setLastVirtualBalances(currentVirtualBalanceA, currentVirtualBalanceB);
-        }
-        _updateTimestamp();
+        _updateVirtualBalances();
 
         // Update the price shift exponent.
         return _setDailyPriceShiftExponent(dailyPriceShiftExponent);
@@ -737,15 +748,7 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
      */
     function _setCenterednessMarginAndUpdateVirtualBalances(uint256 centerednessMargin) internal {
         // Update the virtual balances using the current daily price shift exponent.
-        (, , , uint256[] memory balancesScaled18) = _vault.getPoolTokenInfo(address(this));
-        (uint256 currentVirtualBalanceA, uint256 currentVirtualBalanceB, bool changed) = _computeCurrentVirtualBalances(
-            balancesScaled18
-        );
-        if (changed) {
-            _setLastVirtualBalances(currentVirtualBalanceA, currentVirtualBalanceB);
-        }
-
-        _updateTimestamp();
+        _updateVirtualBalances();
 
         _setCenterednessMargin(centerednessMargin);
     }
@@ -765,6 +768,18 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
         emit CenterednessMarginUpdated(centerednessMargin);
 
         _vault.emitAuxiliaryEvent("CenterednessMarginUpdated", abi.encode(centerednessMargin));
+    }
+
+    function _updateVirtualBalances() internal {
+        (, , , uint256[] memory balancesScaled18) = _vault.getPoolTokenInfo(address(this));
+        (uint256 currentVirtualBalanceA, uint256 currentVirtualBalanceB, bool changed) = _computeCurrentVirtualBalances(
+            balancesScaled18
+        );
+        if (changed) {
+            _setLastVirtualBalances(currentVirtualBalanceA, currentVirtualBalanceB);
+        }
+
+        _updateTimestamp();
     }
 
     // Updates the last timestamp to the current timestamp.

--- a/contracts/interfaces/IReClammPool.sol
+++ b/contracts/interfaces/IReClammPool.sol
@@ -195,6 +195,9 @@ interface IReClammPool is IBasePool {
     /// @dev The price ratio being set is too close to the current one.
     error FourthRootPriceRatioDeltaBelowMin(uint256 fourthRootPriceRatioDelta);
 
+    /// @dev An attempt was made to stop the price ratio update while no update was in progress.
+    error PriceRatioNotUpdating();
+
     /**
      * @notice `getRate` from `IRateProvider` was called on a ReClamm Pool.
      * @dev ReClamm Pools should never be nested. This is because the invariant of the pool is only used to calculate

--- a/contracts/interfaces/IReClammPool.sol
+++ b/contracts/interfaces/IReClammPool.sol
@@ -419,6 +419,14 @@ interface IReClammPool is IBasePool {
     ) external returns (uint256 actualPriceRatioUpdateStartTime);
 
     /**
+     * @notice Stops an ongoing price ratio update.
+     * @dev The price ratio is calculated by interpolating between the start and end times. The new end price ratio
+     * will be set to the current one at the current timestamp, effectively pausing the update.
+     * This is a permissioned function.
+     */
+    function stopPriceRatioUpdate() external;
+
+    /**
      * @notice Updates the daily price shift exponent, as a 18-decimal FP percentage.
      * @dev This function is considered a user interaction, and therefore recalculates the virtual balances and sets
      * the last timestamp. This is a permissioned function.

--- a/test/foundry/ReClammPool.t.sol
+++ b/test/foundry/ReClammPool.t.sol
@@ -322,6 +322,12 @@ contract ReClammPoolTest is BaseReClammTest {
         assertEq(data.minPriceRatioUpdateDuration, 6 hours, "Invalid min price ratio update duration");
     }
 
+    function testSetFourthRootPriceRatioPermissioned() public {
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        vm.prank(alice);
+        ReClammPool(pool).setPriceRatioState(1, block.timestamp, block.timestamp);
+    }
+
     function testSetFourthRootPriceRatioPoolNotInitialized() public {
         vault.manualSetInitializedPool(pool, false);
 
@@ -373,6 +379,12 @@ contract ReClammPoolTest is BaseReClammTest {
         uint96 startFourthRootPriceRatio = ReClammPool(pool).computeCurrentFourthRootPriceRatio().toUint96();
 
         vm.expectEmit();
+        emit IReClammPool.LastTimestampUpdated(block.timestamp.toUint32());
+
+        vm.expectEmit(address(vault));
+        emit IVaultEvents.VaultAuxiliary(pool, "LastTimestampUpdated", abi.encode(block.timestamp.toUint32()));
+
+        vm.expectEmit();
         emit IReClammPool.PriceRatioStateUpdated(
             startFourthRootPriceRatio,
             endFourthRootPriceRatio,
@@ -410,6 +422,226 @@ contract ReClammPoolTest is BaseReClammTest {
         skip(duration / 2 + 1);
         fourthRootPriceRatio = ReClammPool(pool).computeCurrentFourthRootPriceRatio().toUint96();
         assertEq(fourthRootPriceRatio, endFourthRootPriceRatio, "FourthRootPriceRatio does not match new value");
+    }
+
+    /// @dev Trigger a price ratio update while another one is ongoing.
+    function testSetFourthRootPriceRatioOverride() public {
+        uint96 endFourthRootPriceRatio = 2e18;
+        uint32 timeOffset = 1 hours;
+        uint32 priceRatioUpdateStartTime = uint32(block.timestamp) - timeOffset;
+        uint32 duration = 24 hours;
+        uint32 priceRatioUpdateEndTime = uint32(block.timestamp) + duration;
+
+        uint96 startFourthRootPriceRatio = ReClammPool(pool).computeCurrentFourthRootPriceRatio().toUint96();
+
+        // Events:
+        // - Timestamp update
+        // - Price ratio state update
+        // Virtual balances don't change in this case.
+        vm.expectEmit();
+        emit IReClammPool.LastTimestampUpdated(block.timestamp.toUint32());
+
+        vm.expectEmit(address(vault));
+        emit IVaultEvents.VaultAuxiliary(pool, "LastTimestampUpdated", abi.encode(block.timestamp.toUint32()));
+
+        vm.expectEmit();
+        emit IReClammPool.PriceRatioStateUpdated(
+            startFourthRootPriceRatio,
+            endFourthRootPriceRatio,
+            block.timestamp,
+            priceRatioUpdateEndTime
+        );
+
+        vm.expectEmit();
+        emit IVaultEvents.VaultAuxiliary(
+            pool,
+            "PriceRatioStateUpdated",
+            abi.encode(startFourthRootPriceRatio, endFourthRootPriceRatio, block.timestamp, priceRatioUpdateEndTime)
+        );
+
+        vm.prank(admin);
+        uint256 actualPriceRatioUpdateStartTime = ReClammPool(pool).setPriceRatioState(
+            endFourthRootPriceRatio,
+            priceRatioUpdateStartTime,
+            priceRatioUpdateEndTime
+        );
+        assertEq(actualPriceRatioUpdateStartTime, block.timestamp, "Invalid updated actual price ratio start time");
+
+        skip(duration / 2);
+        uint96 fourthRootPriceRatio = ReClammPool(pool).computeCurrentFourthRootPriceRatio().toUint96();
+        uint96 mathFourthRootPriceRatio = mathMock.computeFourthRootPriceRatio(
+            uint32(block.timestamp),
+            startFourthRootPriceRatio,
+            endFourthRootPriceRatio,
+            actualPriceRatioUpdateStartTime.toUint32(),
+            priceRatioUpdateEndTime
+        );
+
+        assertEq(fourthRootPriceRatio, mathFourthRootPriceRatio, "FourthRootPriceRatio not updated correctly");
+
+        // While the update is ongoing, we'll trigger a second one.
+        // This one will update virtual balances too.
+        endFourthRootPriceRatio = 4e18;
+        timeOffset = 1 hours;
+        priceRatioUpdateStartTime = uint32(block.timestamp) - timeOffset;
+        duration = 6 hours;
+        priceRatioUpdateEndTime = uint32(block.timestamp) + duration;
+
+        startFourthRootPriceRatio = ReClammPool(pool).computeCurrentFourthRootPriceRatio().toUint96();
+
+        (uint256 currentVirtualBalanceA, uint256 currentVirtualBalanceB, ) = ReClammPool(pool)
+            .computeCurrentVirtualBalances();
+
+        // Events:
+        // - Virtual balances update
+        // - Timestamp update
+        // - Price ratio state update
+        vm.expectEmit(pool);
+        emit IReClammPool.VirtualBalancesUpdated(currentVirtualBalanceA, currentVirtualBalanceB);
+
+        vm.expectEmit(address(vault));
+        emit IVaultEvents.VaultAuxiliary(
+            pool,
+            "VirtualBalancesUpdated",
+            abi.encode(currentVirtualBalanceA, currentVirtualBalanceB)
+        );
+
+        vm.expectEmit();
+        emit IReClammPool.LastTimestampUpdated(block.timestamp.toUint32());
+
+        vm.expectEmit(address(vault));
+        emit IVaultEvents.VaultAuxiliary(pool, "LastTimestampUpdated", abi.encode(block.timestamp.toUint32()));
+
+        vm.expectEmit();
+        emit IReClammPool.PriceRatioStateUpdated(
+            startFourthRootPriceRatio,
+            endFourthRootPriceRatio,
+            block.timestamp,
+            priceRatioUpdateEndTime
+        );
+
+        vm.expectEmit();
+        emit IVaultEvents.VaultAuxiliary(
+            pool,
+            "PriceRatioStateUpdated",
+            abi.encode(startFourthRootPriceRatio, endFourthRootPriceRatio, block.timestamp, priceRatioUpdateEndTime)
+        );
+
+        vm.prank(admin);
+        actualPriceRatioUpdateStartTime = ReClammPool(pool).setPriceRatioState(
+            endFourthRootPriceRatio,
+            priceRatioUpdateStartTime,
+            priceRatioUpdateEndTime
+        );
+
+        vm.warp(priceRatioUpdateEndTime + 1);
+        fourthRootPriceRatio = ReClammPool(pool).computeCurrentFourthRootPriceRatio().toUint96();
+        assertEq(fourthRootPriceRatio, endFourthRootPriceRatio, "FourthRootPriceRatio does not match new value");
+    }
+
+    function testStopPriceRatioUpdatePermissioned() public {
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        vm.prank(alice);
+        ReClammPool(pool).stopPriceRatioUpdate();
+    }
+
+    function testStopPriceRatioUpdatePoolNotInitialized() public {
+        vault.manualSetInitializedPool(pool, false);
+
+        vm.expectRevert(IReClammPool.PoolNotInitialized.selector);
+        vm.prank(admin);
+        ReClammPool(pool).stopPriceRatioUpdate();
+    }
+
+    function testStopPriceRatioUpdatePriceRatioNotUpdating() public {
+        skip(1 hours);
+        vm.expectRevert(IReClammPool.PriceRatioNotUpdating.selector);
+        vm.prank(admin);
+        ReClammPool(pool).stopPriceRatioUpdate();
+    }
+
+    function testStopPriceRatioUpdate() public {
+        uint96 endFourthRootPriceRatio = 2e18;
+        uint32 timeOffset = 1 hours;
+        uint32 priceRatioUpdateStartTime = uint32(block.timestamp) - timeOffset;
+        uint32 duration = 6 hours;
+        uint32 priceRatioUpdateEndTime = uint32(block.timestamp) + duration;
+
+        uint96 startFourthRootPriceRatio = ReClammPool(pool).computeCurrentFourthRootPriceRatio().toUint96();
+
+        vm.prank(admin);
+        uint256 actualPriceRatioUpdateStartTime = ReClammPool(pool).setPriceRatioState(
+            endFourthRootPriceRatio,
+            priceRatioUpdateStartTime,
+            priceRatioUpdateEndTime
+        );
+
+        skip(duration / 2);
+        uint96 fourthRootPriceRatio = ReClammPool(pool).computeCurrentFourthRootPriceRatio().toUint96();
+        uint96 mathFourthRootPriceRatio = mathMock.computeFourthRootPriceRatio(
+            uint32(block.timestamp),
+            startFourthRootPriceRatio,
+            endFourthRootPriceRatio,
+            actualPriceRatioUpdateStartTime.toUint32(),
+            priceRatioUpdateEndTime
+        );
+
+        assertEq(fourthRootPriceRatio, mathFourthRootPriceRatio, "FourthRootPriceRatio not updated correctly");
+
+        (uint256 currentVirtualBalanceA, uint256 currentVirtualBalanceB, ) = ReClammPool(pool)
+            .computeCurrentVirtualBalances();
+
+        // Events:
+        // - Virtual balances update
+        // - Timestamp update
+        // - Price ratio state update
+        vm.expectEmit(pool);
+        emit IReClammPool.VirtualBalancesUpdated(currentVirtualBalanceA, currentVirtualBalanceB);
+
+        vm.expectEmit(address(vault));
+        emit IVaultEvents.VaultAuxiliary(
+            pool,
+            "VirtualBalancesUpdated",
+            abi.encode(currentVirtualBalanceA, currentVirtualBalanceB)
+        );
+
+        vm.expectEmit();
+        emit IReClammPool.LastTimestampUpdated(block.timestamp.toUint32());
+
+        vm.expectEmit(address(vault));
+        emit IVaultEvents.VaultAuxiliary(pool, "LastTimestampUpdated", abi.encode(block.timestamp.toUint32()));
+
+        // Price ratio update event with current value and timestamp.
+        vm.expectEmit();
+        emit IReClammPool.PriceRatioStateUpdated(
+            fourthRootPriceRatio,
+            fourthRootPriceRatio,
+            block.timestamp,
+            block.timestamp
+        );
+
+        vm.expectEmit();
+        emit IVaultEvents.VaultAuxiliary(
+            pool,
+            "PriceRatioStateUpdated",
+            abi.encode(fourthRootPriceRatio, fourthRootPriceRatio, block.timestamp, block.timestamp)
+        );
+
+        vm.prank(admin);
+        ReClammPool(pool).stopPriceRatioUpdate();
+
+        uint96 fourthRootPriceRatioAfterStop = ReClammPool(pool).computeCurrentFourthRootPriceRatio().toUint96();
+        assertEq(fourthRootPriceRatio, fourthRootPriceRatioAfterStop, "FourthRootPriceRatio changed after stop");
+
+        // Now warp a bit longer and check that it didn't keep changing.
+        skip(duration / 2 + 1);
+
+        uint96 fourthRootPriceRatioAfterWarp = ReClammPool(pool).computeCurrentFourthRootPriceRatio().toUint96();
+        assertEq(
+            fourthRootPriceRatio,
+            fourthRootPriceRatioAfterWarp,
+            "FourthRootPriceRatio changed after stop and warp"
+        );
     }
 
     function testGetRate() public {


### PR DESCRIPTION
# Description

In the current state of the codebase, `setPriceRatioState` can override an ongoing update. This is not an issue, although we  should probably update the virtual balances as we do elsewhere.

We've said that this feature can be used to stop and / or restart a new update, which is desirable. The problem with `stop`, in particular is that `setPriceRatioState` has a few restrictions: the minimum duration of the update has to be 6 hours, and there's also a minimum delta for the value being set. Those two are reasonable constraints IMO, and I'd say it's worth keeping them. However, if the admin wants to just stop the update, they become an issue.

Therefore, I propose:
- Allow `setPriceRatioState` to override current updates (updating virtual balances)
- Add a second setter to just stop the current update on the spot. That way, the user doesn't need to care about timestamp or value deltas when calling it.

Tests pending.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A